### PR TITLE
Pass duplicate tolerance parameter through config

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ impl YoloProject {
 
         let metadata = FileMetadata {
             classes: classes.clone(),
-            duplicate_tolerance: 0.0,
+            duplicate_tolerance: config.export.duplicate_tolerance,
         };
 
         let pairs = pair(metadata, stems.clone(), label_paths, image_paths);

--- a/src/yolo_file.rs
+++ b/src/yolo_file.rs
@@ -256,7 +256,7 @@ impl YoloFile {
                 label_coordinates.push((x1, x2, y1, y2))
             }
 
-            let tolerance = 0.01;
+            let tolerance = metadata.duplicate_tolerance;
             if let Some(indices) = Self::get_duplicate_index(&label_coordinates, tolerance) {
                 return Err(YoloFileParseError::DuplicateEntries(
                     YoloFileParseErrorDetails {

--- a/tests/invalid_label_tests.rs
+++ b/tests/invalid_label_tests.rs
@@ -335,4 +335,22 @@ mod invalid_label_tests {
             panic!("Expected error");
         }
     }
+
+    #[test]
+    fn test_yolo_file_new_allows_duplicates_when_tolerance_zero() {
+        let filename = "tolerance_zero.txt";
+        let classes_raw = vec![(0, "person")];
+        let classes = create_yolo_classes(classes_raw.clone());
+        let (mut metadata, path) = create_yolo_label_file(
+            filename,
+            classes.clone(),
+            "0 0.25 0.5 0.25 0.5\n0 0.25 0.5 0.25 0.5",
+        );
+
+        metadata.duplicate_tolerance = 0.0;
+
+        let yolo_file = YoloFile::new(&metadata, &path);
+
+        assert!(yolo_file.is_ok());
+    }
 }


### PR DESCRIPTION
## Summary
- plumb YoloProjectConfig.export.duplicate_tolerance into `FileMetadata`
- respect `metadata.duplicate_tolerance` when detecting duplicate label entries
- test duplicate handling with zero tolerance

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686ab1eb66cc83228dd19a48a799c019