### PR TITLE
Fix extension comparison

### DIFF
--- a/src/file_utils.rs
+++ b/src/file_utils.rs
@@ -53,6 +53,7 @@ pub fn get_filepaths_for_extension(
     let file_paths = std::fs::read_dir(path).map_err(|err| FileError::ReadFile(err.to_string()))?;
 
     let mut paths = Vec::<PathWithKey>::new();
+    let extensions_lower: Vec<String> = extensions.iter().map(|ext| ext.to_lowercase()).collect();
 
     for file_path in file_paths {
         let file_path = file_path
@@ -69,7 +70,7 @@ pub fn get_filepaths_for_extension(
         }
 
         let extension = match get_file_extension(&file_path) {
-            Ok(extension) => extension,
+            Ok(extension) => extension.to_lowercase(),
             Err(_) => continue,
         };
 
@@ -78,13 +79,16 @@ pub fn get_filepaths_for_extension(
             Err(_) => continue,
         };
 
-        if extensions.contains(&extension) {
+        if extensions_lower.contains(&extension) {
             paths.push(PathWithKey {
                 path: file_path.clone(),
                 key: String::from(stem),
             });
         }
     }
+
+    // Ensure deterministic order of returned paths
+    paths.sort_by(|a, b| a.path.cmp(&b.path));
 
     Ok(paths)
 }

--- a/tests/pairing_tests.rs
+++ b/tests/pairing_tests.rs
@@ -185,4 +185,31 @@ mod pairing_tests {
         assert!(valid_pair.is_none());
         assert!(invalid_pair.is_none());
     }
+
+    #[rstest]
+    fn test_project_validation_handles_mixed_case_extensions(
+        image_data: ImageBuffer<Rgb<u8>, Vec<u8>>,
+        mut create_yolo_project_config: YoloProjectConfig,
+    ) {
+        let filename = "mixed_case";
+        let this_test_directory = format!("{}/{}/", TEST_SANDBOX_DIR, filename);
+
+        let image_file = PathBuf::from(format!("{}/test1.JpG", this_test_directory));
+        create_image_file(&image_file, &image_data);
+
+        let label_file = PathBuf::from(format!("{}/test1.TxT", this_test_directory));
+        create_dir_and_write_file(&label_file, "0 0.5 0.5 0.5 0.5");
+
+        create_yolo_project_config.source_paths.images = this_test_directory.clone();
+        create_yolo_project_config.source_paths.labels = this_test_directory.clone();
+
+        let project =
+            YoloProject::new(&create_yolo_project_config).expect("Unable to create project");
+
+        let valid_pairs = project.get_valid_pairs();
+
+        let valid_pair = valid_pairs.into_iter().find(|pair| pair.name == "test1");
+
+        assert!(valid_pair.is_some());
+    }
 }


### PR DESCRIPTION
## Summary
- make extension comparisons case-insensitive
- keep file traversal deterministic
- add regression test for mixed‑case filenames

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686ab1ecc380832295c83286d62d7ff4