### PR TITLE
Improve duplicate pair Display output

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -186,6 +186,12 @@ pub struct DuplicateImageLabelPair {
     pub duplicate: ImageLabelPair,
 }
 
+impl std::fmt::Display for DuplicateImageLabelPair {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Duplicate image and label files for '{}'", self.name)
+    }
+}
+
 #[derive(Error, Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub enum PairingError {
     LabelFileError(YoloFileParseError),
@@ -216,8 +222,8 @@ impl std::fmt::Display for PairingError {
             PairingError::ImageFileMissingUnableToUnwrapLabelPath => {
                 write!(f, "Image file missing; unable to unwrap label path")
             }
-            PairingError::Duplicate(_) => {
-                write!(f, "Duplicate image and label files")
+            PairingError::Duplicate(duplicate) => {
+                write!(f, "{}", duplicate)
             }
         }
     }


### PR DESCRIPTION
## Summary
- include the file stem in the `DuplicateImageLabelPair` display
- delegate `PairingError::Duplicate` formatting to the new implementation

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686ab1ef80ac832299b6c1988ddef169