### PR TITLE
Document r#type and fix pairing order

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,10 @@ This crate is very much a work-in-progress.  Features outlined may not be comple
 
 ## Reads
 - [YOLO Format](https://docs.ultralytics.com/yolov5/tutorials/train_custom_data/#21-create-datasetyaml)
+
+## Configuration
+
+`yolo_io` expects a YAML configuration file when building a project. The
+`type` field inside this file denotes the project format. Today only the
+`"yolo"` type is recognized, but this key remains so other formats can be
+supported later.

--- a/src/pairing.rs
+++ b/src/pairing.rs
@@ -15,21 +15,29 @@ pub fn pair(
     let mut pairs: Vec<PairingResult> = Vec::new();
 
     for stem in stems {
-        let image_paths_for_stem = image_filenames
-            .clone()
-            .into_iter()
+        let mut image_paths_for_stem = image_filenames
+            .iter()
             .filter(|image| image.key == *stem)
-            .map(|image| match image.clone().path.to_str() {
+            .map(|image| image.path.clone())
+            .collect::<Vec<PathBuf>>();
+        image_paths_for_stem.sort();
+        let image_paths_for_stem = image_paths_for_stem
+            .iter()
+            .map(|image| match image.to_str() {
                 Some(path) => Ok(path.to_string()),
                 None => Err(()),
             })
             .collect::<Vec<Result<String, ()>>>();
 
-        let label_paths_for_stem = label_filenames
-            .clone()
-            .into_iter()
+        let mut label_paths_for_stem = label_filenames
+            .iter()
             .filter(|label| label.key == *stem)
-            .map(|label| match label.clone().path.to_str() {
+            .map(|label| label.path.clone())
+            .collect::<Vec<PathBuf>>();
+        label_paths_for_stem.sort();
+        let label_paths_for_stem = label_paths_for_stem
+            .iter()
+            .map(|label| match label.to_str() {
                 Some(path) => Ok(path.to_string()),
                 None => Err(()),
             })

--- a/src/types.rs
+++ b/src/types.rs
@@ -136,9 +136,12 @@ pub struct FileMetadata {
     pub duplicate_tolerance: f32,
 }
 
+/// Configuration for a YOLO project.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct YoloProjectConfig {
     pub source_paths: SourcePaths,
+    /// Identifies the project format. Currently only "yolo" is supported but
+    /// this field is reserved for future project types.
     pub r#type: String,
     pub project_name: String,
     pub export: Export,


### PR DESCRIPTION
## Summary
- explain the `type` field for project configuration
- sort file paths in `pair` to ensure deterministic pairings

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686ab1f1103083229fafdf1dc68d353f