### PR TITLE
Fix empty data quality report return behavior

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -30,7 +30,11 @@ impl YoloDataQualityReport {
             }
         }
 
-        serde_json::to_string(&errors).ok()
+        if errors.is_empty() {
+            None
+        } else {
+            serde_json::to_string(&errors).ok()
+        }
     }
 
     fn get_source_name(pairing_error: &PairingError) -> String {


### PR DESCRIPTION
## Summary
- prevent returning an empty report string

## Testing
- `cargo test --quiet` *(fails: pairing_tests::test_project_validation_produces_one_valid_pair_for_one_image_two_labels)*

------
https://chatgpt.com/codex/tasks/task_e_686ab1f2b750832286f9df3e5e612a13