### PR TITLE
Fix copy file error message

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -16,7 +16,7 @@ pub enum ExportError {
     UnableToCreateDirectory(String),
     #[error("Failed to unwrap label path.")]
     FailedToUnwrapLabelPath,
-    #[error("Failed to copy file '{0}' to '{0}'.")]
+    #[error("Failed to copy file '{0}' to '{1}'.")]
     FailedToCopyFile(String, String),
 }
 


### PR DESCRIPTION
## Summary
- fix an incorrect export error message for file copying

## Testing
- `cargo test` *(fails: pairing_tests::test_project_validation_produces_one_valid_pair_for_one_image_two_labels)*

------
https://chatgpt.com/codex/tasks/task_e_686ab1f787b88322a9747595d4eaefc7