### PR TITLE
Remove println! and add logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0.129"
 serde_yml = "0.0.12"
 thiserror = "1.0"
+log = "0.4"
 
 [dev-dependencies]
 image = "0.25.4" # https://docs.rs/image/latest/image/

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,4 +1,5 @@
 use hashbrown::HashMap;
+use log::debug;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 use std::fs;
@@ -89,7 +90,7 @@ impl YoloProjectExporter {
         pairs: Vec<ImageLabelPair>,
     ) -> Result<(), ExportError> {
         for pair in pairs {
-            println!("pair: {:?}", pair);
+            debug!("pair: {:?}", pair);
 
             let image_path = pair
                 .image_path

--- a/src/file_utils.rs
+++ b/src/file_utils.rs
@@ -86,5 +86,8 @@ pub fn get_filepaths_for_extension(
         }
     }
 
+    // Ensure deterministic ordering
+    paths.sort_by(|a, b| a.path.cmp(&b.path));
+
     Ok(paths)
 }

--- a/tests/duplicate_testing.rs
+++ b/tests/duplicate_testing.rs
@@ -47,9 +47,6 @@ mod duplicate_tests {
         let valid_pairs = project.get_valid_pairs();
         let invalid_pairs = project.get_invalid_pairs();
 
-        println!("{:#?}", valid_pairs);
-        println!("{:#?}", invalid_pairs);
-
         let valid_pair = valid_pairs.into_iter().find(|pair| pair.name == "test1");
         let invalid_pair = invalid_pairs
             .into_iter()
@@ -113,9 +110,6 @@ mod duplicate_tests {
 
         let valid_pairs = project.get_valid_pairs();
         let invalid_pairs = project.get_invalid_pairs();
-
-        println!("{:#?}", valid_pairs);
-        println!("{:#?}", invalid_pairs);
 
         let valid_pair = valid_pairs.into_iter().find(|pair| pair.name == file_key);
         let invalid_pairs = invalid_pairs

--- a/tests/export_tests.rs
+++ b/tests/export_tests.rs
@@ -96,8 +96,6 @@ mod tests {
 
         let yolo_yaml_path = format!("{}/test_project.yaml", exported_config.export.paths.root);
 
-        println!("Yolo YAML Path: {}", yolo_yaml_path);
-
         let expected_yaml = r#"# Generate by yolo_io - https://github.com/Ladvien/yolo_io
 path: tests/sandbox/export_test_yolo_yaml_created
 train: train/


### PR DESCRIPTION
## Summary
- replace debugging `println!` in `src/export.rs` with `log::debug!`
- ensure deterministic file ordering in `get_filepaths_for_extension`
- remove stray `println!` statements from tests
- add `log` crate dependency

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686ab1f8c784832285162271b73cd9e7