### PR TITLE
Resolve leftover merge conflicts

### DIFF
--- a/src/file_utils.rs
+++ b/src/file_utils.rs
@@ -91,11 +91,8 @@ pub fn get_filepaths_for_extension(
         }
     }
 
-<<<<<<< HEAD
     // Ensure deterministic order of returned paths
-=======
-    // Ensure deterministic ordering
->>>>>>> a15e54f336d7a1622e4e078ede83bbfac7bb626c
+
     paths.sort_by(|a, b| a.path.cmp(&b.path));
 
     Ok(paths)

--- a/src/pairing.rs
+++ b/src/pairing.rs
@@ -17,17 +17,13 @@ pub fn pair(
 
     for stem in stems {
         let mut image_paths_for_stem = image_filenames
-<<<<< HEAD
-            .iter()
-======
             .clone()
             .into_iter()
->>>>> 5664eeae26253c3b7baffffbabeffeaeec214498
             .filter(|image| image.key == *stem)
             .map(|image| image.path.clone())
             .collect::<Vec<PathBuf>>();
         image_paths_for_stem.sort();
-        let image_paths_for_stem = image_paths_for_stem
+        let mut image_paths_for_stem = image_paths_for_stem
             .iter()
             .map(|image| match image.to_str() {
                 Some(path) => Ok(path.to_string()),
@@ -35,10 +31,6 @@ pub fn pair(
             })
             .collect::<Vec<Result<String, ()>>>();
 
-<<<<< HEAD
-        let mut label_paths_for_stem = label_filenames
-            .iter()
-======
         image_paths_for_stem.sort_by(|a, b| {
             let a_str = a.as_ref().map(|s| s.as_str()).unwrap_or("");
             let b_str = b.as_ref().map(|s| s.as_str()).unwrap_or("");
@@ -48,12 +40,11 @@ pub fn pair(
         let mut label_paths_for_stem = label_filenames
             .clone()
             .into_iter()
->>>>>> 5664eeae26253c3b7baffffbabeffeaeec214498
             .filter(|label| label.key == *stem)
             .map(|label| label.path.clone())
             .collect::<Vec<PathBuf>>();
         label_paths_for_stem.sort();
-        let label_paths_for_stem = label_paths_for_stem
+        let mut label_paths_for_stem = label_paths_for_stem
             .iter()
             .map(|label| match label.to_str() {
                 Some(path) => Ok(path.to_string()),
@@ -61,18 +52,13 @@ pub fn pair(
             })
             .collect::<Vec<Result<String, ()>>>();
 
-<<<<<< agentic
         label_paths_for_stem.sort_by(|a, b| {
             let a_str = a.as_ref().map(|s| s.as_str()).unwrap_or("");
             let b_str = b.as_ref().map(|s| s.as_str()).unwrap_or("");
             a_str.cmp(b_str)
         });
-
-        let invalid_pairs = process_label_path(&file_metadata, label_paths_for_stem.clone());
-=======
         let (invalid_pairs, valid_label_paths) =
             process_label_path(&file_metadata, label_paths_for_stem);
->>>>>> main
 
         let label_paths_for_stem = valid_label_paths
             .into_iter()

--- a/src/types.rs
+++ b/src/types.rs
@@ -177,12 +177,8 @@ pub struct FileMetadata {
 pub struct YoloProjectConfig {
     /// Location of images and labels to scan.
     pub source_paths: SourcePaths,
-<<<<<<< HEAD
     /// Identifies the project format. Currently only "yolo" is supported but
     /// this field is reserved for future project types.
-=======
-    /// Type of project, currently always "yolo".
->>>>>>> a70e8c027a2b221f4edca79f180332770abbb8a1
     pub r#type: String,
     /// Name of the project.
     pub project_name: String,

--- a/tests/duplicate_testing.rs
+++ b/tests/duplicate_testing.rs
@@ -132,26 +132,6 @@ mod duplicate_tests {
     }
 
     #[rstest]
-<<<<<<< HEAD
-    fn test_duplicate_pairs_with_different_labels(
-        mut create_yolo_project_config: YoloProjectConfig,
-        image_data: ImageBuffer<Rgb<u8>, Vec<u8>>,
-    ) {
-        let filename = "dup_three";
-        let this_test_directory = format!("{}/{}/", TEST_SANDBOX_DIR, filename);
-
-        let image_file = PathBuf::from(format!("{}/test1.jpg", this_test_directory));
-        create_image_file(&image_file, &image_data);
-
-        let image_file_duplicate = PathBuf::from(format!("{}/else/test1.jpg", this_test_directory));
-        create_image_file(&image_file_duplicate, &image_data);
-
-        let label_file = PathBuf::from(format!("{}/test1.txt", this_test_directory));
-        create_dir_and_write_file(&label_file, "0 0.5 0.5 0.5 0.5");
-
-        let label_file_duplicate = PathBuf::from(format!("{}/else/test1.txt", this_test_directory));
-        create_dir_and_write_file(&label_file_duplicate, "1 0.5 0.5 0.5 0.5");
-=======
     fn test_duplicate_label_files_with_different_data(
         mut create_yolo_project_config: YoloProjectConfig,
         image_data: ImageBuffer<Rgb<u8>, Vec<u8>>,
@@ -172,21 +152,12 @@ mod duplicate_tests {
         let label_file_duplicate =
             PathBuf::from(format!("{}/elsewhere/test.txt", this_test_directory));
         create_dir_and_write_file(&label_file_duplicate, "0 0.6 0.6 0.5 0.5");
->>>>>>> cff4fcbe87749809e691fd884dbed988fac6624a
 
         create_yolo_project_config.source_paths.images = this_test_directory.clone();
         create_yolo_project_config.source_paths.labels = this_test_directory.clone();
 
         let project = YoloProject::new(&create_yolo_project_config).unwrap();
 
-<<<<<<< HEAD
-        let invalid_pairs = project.get_invalid_pairs();
-        let mismatch = invalid_pairs
-            .into_iter()
-            .find(|pair| matches!(pair, yolo_io::PairingError::DuplicateLabelMismatch(_)));
-
-        assert!(mismatch.is_some());
-=======
         let valid_pairs = project.get_valid_pairs();
         let invalid_pairs = project.get_invalid_pairs();
 
@@ -197,6 +168,5 @@ mod duplicate_tests {
 
         assert!(valid_pair.is_some());
         assert!(duplicate_error.is_some());
->>>>>>> cff4fcbe87749809e691fd884dbed988fac6624a
     }
 }

--- a/tests/invalid_label_tests.rs
+++ b/tests/invalid_label_tests.rs
@@ -336,24 +336,6 @@ mod invalid_label_tests {
         }
     }
 
-<<<<<<< HEAD
-    #[test]
-    fn test_yolo_file_new_allows_duplicates_when_tolerance_zero() {
-        let filename = "tolerance_zero.txt";
-        let classes_raw = vec![(0, "person")];
-        let classes = create_yolo_classes(classes_raw.clone());
-        let (mut metadata, path) = create_yolo_label_file(
-            filename,
-            classes.clone(),
-            "0 0.25 0.5 0.25 0.5\n0 0.25 0.5 0.25 0.5",
-        );
-
-        metadata.duplicate_tolerance = 0.0;
-
-        let yolo_file = YoloFile::new(&metadata, &path);
-
-        assert!(yolo_file.is_ok());
-=======
     fn create_yolo_label_file_with_tolerance(
         filename: &str,
         classes: Vec<YoloClass>,
@@ -392,6 +374,5 @@ mod invalid_label_tests {
             yolo_file,
             Err(YoloFileParseError::DuplicateEntries(_))
         ));
->>>>>>> cff4fcbe87749809e691fd884dbed988fac6624a
     }
 }

--- a/tests/pairing_tests.rs
+++ b/tests/pairing_tests.rs
@@ -187,19 +187,6 @@ mod pairing_tests {
     }
 
     #[rstest]
-<<<<<<< HEAD
-    fn test_project_validation_handles_mixed_case_extensions(
-        image_data: ImageBuffer<Rgb<u8>, Vec<u8>>,
-        mut create_yolo_project_config: YoloProjectConfig,
-    ) {
-        let filename = "mixed_case";
-        let this_test_directory = format!("{}/{}/", TEST_SANDBOX_DIR, filename);
-
-        let image_file = PathBuf::from(format!("{}/test1.JpG", this_test_directory));
-        create_image_file(&image_file, &image_data);
-
-        let label_file = PathBuf::from(format!("{}/test1.TxT", this_test_directory));
-=======
     fn test_pairing_with_mixed_case_extensions(
         image_data: ImageBuffer<Rgb<u8>, Vec<u8>>,
         mut create_yolo_project_config: YoloProjectConfig,
@@ -207,13 +194,11 @@ mod pairing_tests {
         let filename = "mixed_ext";
         let this_test_directory = format!("{}/{}/", TEST_SANDBOX_DIR, filename);
 
-        let image_file =
-            PathBuf::from(format!("{}/testMiXeD.JpG", this_test_directory));
+        let image_file = PathBuf::from(format!("{}/testMiXeD.JpG", this_test_directory));
         create_image_file(&image_file, &image_data);
 
-        let label_file =
-            PathBuf::from(format!("{}/testMiXeD.TxT", this_test_directory));
->>>>>>> cff4fcbe87749809e691fd884dbed988fac6624a
+        let label_file = PathBuf::from(format!("{}/testMiXeD.TxT", this_test_directory));
+
         create_dir_and_write_file(&label_file, "0 0.5 0.5 0.5 0.5");
 
         create_yolo_project_config.source_paths.images = this_test_directory.clone();
@@ -223,14 +208,9 @@ mod pairing_tests {
             YoloProject::new(&create_yolo_project_config).expect("Unable to create project");
 
         let valid_pairs = project.get_valid_pairs();
-<<<<<<< HEAD
-
-        let valid_pair = valid_pairs.into_iter().find(|pair| pair.name == "test1");
-=======
         let valid_pair = valid_pairs
             .into_iter()
             .find(|pair| pair.name == "testMiXeD");
->>>>>>> cff4fcbe87749809e691fd884dbed988fac6624a
 
         assert!(valid_pair.is_some());
     }


### PR DESCRIPTION
## Summary
- clean up merge artifacts across source and tests
- keep deterministic ordering in file utilities
- update pairing logic and associated tests

## Testing
- `cargo check`
- `cargo test` *(fails: duplicate_tests::test_duplicate_label_files_with_different_data)*

------
https://chatgpt.com/codex/tasks/task_e_686acdcde6f883229ab2a702bc9eea79