### PR TITLE
Fix export naming

### DIFF
--- a/tests/export_tests.rs
+++ b/tests/export_tests.rs
@@ -17,6 +17,8 @@ mod tests {
         mut create_yolo_project_config: YoloProjectConfig,
         export_name: String,
         image_data: ImageBuffer<Rgb<u8>, Vec<u8>>,
+        image_ext: &str,
+        label_ext: &str,
     ) -> YoloProjectConfig {
         let export_source_dir = format!("{}/export_source_{}", TEST_SANDBOX_DIR, export_name);
         let export_out_dir = format!("{}/export_{}", TEST_SANDBOX_DIR, export_name);
@@ -39,8 +41,8 @@ mod tests {
 
         let num_of_pairs = 10;
         for i in 0..num_of_pairs {
-            let image_path = format!("{}/test_{}.jpg", export_source_dir, i);
-            let label_path = format!("{}/test_{}.txt", export_source_dir, i);
+            let image_path = format!("{}/test_{}.{}", export_source_dir, i, image_ext);
+            let label_path = format!("{}/test_{}.{}", export_source_dir, i, label_ext);
             image_data.save(&image_path).expect("Unable to save image");
             create_dir_and_write_file(std::path::Path::new(&label_path), "0 0.5 0.5 0.5 0.5");
         }
@@ -60,6 +62,8 @@ mod tests {
             create_yolo_project_config,
             "test_splits_correctly".to_string(),
             image_data(),
+            "jpg",
+            "txt",
         );
         let train_image_path = format!("{}/train/images", exported_config.export.paths.root);
 
@@ -92,6 +96,8 @@ mod tests {
             create_yolo_project_config,
             "test_yolo_yaml_created".to_string(),
             image_data(),
+            "jpg",
+            "txt",
         );
 
         let yolo_yaml_path = format!("{}/test_project.yaml", exported_config.export.paths.root);
@@ -110,5 +116,42 @@ names:
         let yolo_yaml = fs::read_to_string(yolo_yaml_path).expect("Unable to read yolo.yaml");
 
         assert_eq!(yolo_yaml, expected_yaml);
+    }
+
+    #[rstest]
+    fn test_export_preserves_extensions(create_yolo_project_config: YoloProjectConfig) {
+        let exported_config = run_export(
+            create_yolo_project_config,
+            "test_extensions".to_string(),
+            image_data(),
+            "jpeg",
+            "data",
+        );
+
+        let image_dirs = vec![
+            format!("{}/train/images", exported_config.export.paths.root),
+            format!("{}/validation/images", exported_config.export.paths.root),
+            format!("{}/test/images", exported_config.export.paths.root),
+        ];
+
+        for dir in image_dirs {
+            for entry in fs::read_dir(dir).unwrap() {
+                let path = entry.unwrap().path();
+                assert_eq!(path.extension().unwrap().to_str().unwrap(), "jpeg");
+            }
+        }
+
+        let label_dirs = vec![
+            format!("{}/train/labels", exported_config.export.paths.root),
+            format!("{}/validation/labels", exported_config.export.paths.root),
+            format!("{}/test/labels", exported_config.export.paths.root),
+        ];
+
+        for dir in label_dirs {
+            for entry in fs::read_dir(dir).unwrap() {
+                let path = entry.unwrap().path();
+                assert_eq!(path.extension().unwrap().to_str().unwrap(), "data");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- preserve file extensions when exporting project files
- update tests to ensure extensions are kept

## Testing
- `cargo test --no-run` *(fails: encountered diff marker src/file_utils.rs:94)*

------
https://chatgpt.com/codex/tasks/task_e_686ad00def008322860d70d48c3b3779