### PR TITLE
Improve yolo_io docs and add usage example

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -31,6 +31,10 @@ pub struct YoloProjectExporter {
 
 impl YoloProjectExporter {
     /// Write the given [`YoloProject`] to disk according to its configuration.
+    ///
+    /// The dataset is copied into the directory structure defined by
+    /// [`crate::Export::paths`]. Existing files are overwritten. Any errors
+    /// during file operations are reported via [`ExportError`].
     pub fn export(project: YoloProject) -> Result<(), ExportError> {
         let paths = &project.config.export.paths;
 

--- a/src/file_utils.rs
+++ b/src/file_utils.rs
@@ -91,11 +91,7 @@ pub fn get_filepaths_for_extension(
         }
     }
 
-<<<<<<< HEAD
-    // Ensure deterministic order of returned paths
-=======
     // Ensure deterministic ordering
->>>>>>> a15e54f336d7a1622e4e078ede83bbfac7bb626c
     paths.sort_by(|a, b| a.path.cmp(&b.path));
 
     Ok(paths)

--- a/src/pairing.rs
+++ b/src/pairing.rs
@@ -17,28 +17,18 @@ pub fn pair(
 
     for stem in stems {
         let mut image_paths_for_stem = image_filenames
-<<<<< HEAD
             .iter()
-======
-            .clone()
-            .into_iter()
->>>>> 5664eeae26253c3b7baffffbabeffeaeec214498
             .filter(|image| image.key == *stem)
             .map(|image| image.path.clone())
             .collect::<Vec<PathBuf>>();
         image_paths_for_stem.sort();
-        let image_paths_for_stem = image_paths_for_stem
+        let mut image_paths_for_stem = image_paths_for_stem
             .iter()
             .map(|image| match image.to_str() {
                 Some(path) => Ok(path.to_string()),
                 None => Err(()),
             })
             .collect::<Vec<Result<String, ()>>>();
-
-<<<<< HEAD
-        let mut label_paths_for_stem = label_filenames
-            .iter()
-======
         image_paths_for_stem.sort_by(|a, b| {
             let a_str = a.as_ref().map(|s| s.as_str()).unwrap_or("");
             let b_str = b.as_ref().map(|s| s.as_str()).unwrap_or("");
@@ -46,33 +36,26 @@ pub fn pair(
         });
 
         let mut label_paths_for_stem = label_filenames
-            .clone()
-            .into_iter()
->>>>>> 5664eeae26253c3b7baffffbabeffeaeec214498
+            .iter()
             .filter(|label| label.key == *stem)
             .map(|label| label.path.clone())
             .collect::<Vec<PathBuf>>();
         label_paths_for_stem.sort();
-        let label_paths_for_stem = label_paths_for_stem
+        let mut label_paths_for_stem = label_paths_for_stem
             .iter()
             .map(|label| match label.to_str() {
                 Some(path) => Ok(path.to_string()),
                 None => Err(()),
             })
             .collect::<Vec<Result<String, ()>>>();
-
-<<<<<< agentic
         label_paths_for_stem.sort_by(|a, b| {
             let a_str = a.as_ref().map(|s| s.as_str()).unwrap_or("");
             let b_str = b.as_ref().map(|s| s.as_str()).unwrap_or("");
             a_str.cmp(b_str)
         });
 
-        let invalid_pairs = process_label_path(&file_metadata, label_paths_for_stem.clone());
-=======
         let (invalid_pairs, valid_label_paths) =
             process_label_path(&file_metadata, label_paths_for_stem);
->>>>>> main
 
         let label_paths_for_stem = valid_label_paths
             .into_iter()

--- a/src/report.rs
+++ b/src/report.rs
@@ -21,6 +21,10 @@ pub struct YoloDataQualityReport;
 
 impl YoloDataQualityReport {
     /// Create a JSON report from a [`YoloProject`].
+    ///
+    /// All invalid pairs are converted into a list of [`DataQualityItem`]
+    /// structures and serialized to JSON. If the project contains no
+    /// errors `None` is returned.
     pub fn generate(project: YoloProject) -> Option<String> {
         let mut errors = Vec::<DataQualityItem>::new();
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,6 +18,9 @@ pub struct Split {
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 /// Settings controlling dataset export.
+///
+/// These options determine where the processed dataset will be
+/// written and how duplicates and splits are handled.
 pub struct Export {
     /// Directory layout for the exported dataset.
     pub paths: Paths,
@@ -31,6 +34,9 @@ pub struct Export {
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 /// Collection of paths used during export.
+///
+/// The values are joined with the project root to form the final
+/// directory layout written by [`crate::YoloProjectExporter`].
 pub struct Paths {
     /// Root directory for exported data.
     pub root: String,
@@ -173,16 +179,15 @@ pub struct FileMetadata {
 
 /// Configuration for a YOLO project.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-/// Top level configuration for a [`YoloProject`].
+/// Top level configuration for a [`crate::YoloProject`].
+///
+/// This structure mirrors the fields of the `config.yaml` file and is
+/// typically loaded using [`YoloProjectConfig::new`].
 pub struct YoloProjectConfig {
     /// Location of images and labels to scan.
     pub source_paths: SourcePaths,
-<<<<<<< HEAD
-    /// Identifies the project format. Currently only "yolo" is supported but
-    /// this field is reserved for future project types.
-=======
-    /// Type of project, currently always "yolo".
->>>>>>> a70e8c027a2b221f4edca79f180332770abbb8a1
+    /// Identifies the project format. Currently only "yolo" is supported,
+    /// but this field is reserved for future project types.
     pub r#type: String,
     /// Name of the project.
     pub project_name: String,
@@ -249,6 +254,9 @@ impl std::fmt::Display for DuplicateImageLabelPair {
 
 #[derive(Error, Clone, PartialEq, Debug, Serialize, Deserialize)]
 /// Reasons why a stem could not be paired.
+///
+/// These errors are produced during project loading when an image and
+/// label file cannot be matched or validated.
 pub enum PairingError {
     LabelFileError(YoloFileParseError),
     BothFilesMissing,

--- a/src/yolo_file.rs
+++ b/src/yolo_file.rs
@@ -85,6 +85,9 @@ pub struct YoloEntry {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 /// Representation of a `.txt` label file in YOLO format.
+///
+/// Each entry corresponds to a bounding box annotation. Instances of
+/// this struct are typically created via [`YoloFile::new`].
 pub struct YoloFile {
     /// File stem without extension.
     pub stem: String,
@@ -96,6 +99,11 @@ pub struct YoloFile {
 
 impl YoloFile {
     /// Read and validate a label file.
+    ///
+    /// The contents are parsed and checked against the supplied
+    /// [`FileMetadata`]. If validation succeeds the parsed file is
+    /// returned, otherwise a [`YoloFileParseError`] describing the
+    /// issue is produced.
     pub fn new(metadata: &FileMetadata, path: &String) -> Result<YoloFile, YoloFileParseError> {
         let potential_file = read_to_string(path);
 


### PR DESCRIPTION
## Summary
- add crate-level example of typical usage
- document key structs (`YoloProject`, `YoloProjectConfig`, `YoloFile`, `PairingError`, `Export`, `Paths`)
- document important methods including `YoloProject::new`, `YoloFile::new`, `YoloProjectExporter::export`, and `YoloDataQualityReport::generate`
- fix leftover merge markers
- verify documentation builds

## Testing
- `cargo doc --no-deps`
- `cargo test --quiet` *(fails: unclosed delimiters in tests)*

------
https://chatgpt.com/codex/tasks/task_e_686ad01af3848322a3296c6cdecd51f5