### PR TITLE
Clean dead error variant

### DIFF
--- a/src/pairing.rs
+++ b/src/pairing.rs
@@ -181,7 +181,7 @@ pub fn evaluate_pair(
             (Err(_), Ok(label_path)) => {
                 PairingResult::Invalid(PairingError::ImageFileMissing(label_path))
             }
-            (Err(_), Err(_)) => PairingResult::Invalid(PairingError::BothFilesMissing),
+            (Err(_), Err(_)) => unreachable!("both image and label paths missing after validation"),
         },
         EitherOrBoth::Left(image_path) => match image_path {
             Ok(image_path) => PairingResult::Invalid(PairingError::LabelFileMissing(image_path)),

--- a/src/report.rs
+++ b/src/report.rs
@@ -69,7 +69,6 @@ impl YoloDataQualityReport {
                     String::from("YoloFileParseError::FailedToGetFileStem")
                 }
             },
-            PairingError::BothFilesMissing => String::from("BothFilesMissing"),
             PairingError::LabelFileMissing(_) => String::from("LabelFileMissing"),
             PairingError::LabelFileMissingUnableToUnwrapImagePath => {
                 String::from("LabelFileMissingUnableToUnwrapImagePath")

--- a/src/types.rs
+++ b/src/types.rs
@@ -251,7 +251,6 @@ impl std::fmt::Display for DuplicateImageLabelPair {
 /// Reasons why a stem could not be paired.
 pub enum PairingError {
     LabelFileError(YoloFileParseError),
-    BothFilesMissing,
     LabelFileMissing(String),
     LabelFileMissingUnableToUnwrapImagePath,
     ImageFileMissing(String),
@@ -266,7 +265,6 @@ impl std::fmt::Display for PairingError {
             PairingError::LabelFileError(error) => {
                 write!(f, "Label file error: {}", error)
             }
-            PairingError::BothFilesMissing => write!(f, "Both files missing"),
             PairingError::LabelFileMissing(path) => {
                 write!(f, "Label file missing: {}", path)
             }

--- a/tests/pairing_tests.rs
+++ b/tests/pairing_tests.rs
@@ -158,35 +158,6 @@ mod pairing_tests {
     }
 
     #[rstest]
-    fn test_project_validation_produces_one_invalid_pair_for_no_image_no_label(
-        mut create_yolo_project_config: YoloProjectConfig,
-    ) {
-        // THIS ERROR IS IMPOSSIBLE TO TRIGGER
-        let filename = "five";
-        let this_test_directory = format!("{}/{}/", TEST_SANDBOX_DIR, filename);
-
-        fs::create_dir_all(&this_test_directory).expect("Unable to create directory");
-
-        create_yolo_project_config.source_paths.images = this_test_directory.clone();
-        create_yolo_project_config.source_paths.labels = this_test_directory.clone();
-
-        let project =
-            YoloProject::new(&create_yolo_project_config).expect("Unable to create project");
-
-        let valid_pairs = project.get_valid_pairs();
-        let valid_pair = valid_pairs.into_iter().find(|pair| pair.name == "test5");
-
-        let invalid_pairs = project.get_invalid_pairs();
-
-        let invalid_pair = invalid_pairs
-            .into_iter()
-            .find(|pair| matches!(pair, yolo_io::PairingError::BothFilesMissing));
-
-        assert!(valid_pair.is_none());
-        assert!(invalid_pair.is_none());
-    }
-
-    #[rstest]
 <<<<<<< HEAD
     fn test_project_validation_handles_mixed_case_extensions(
         image_data: ImageBuffer<Rgb<u8>, Vec<u8>>,


### PR DESCRIPTION
## Summary
- drop `BothFilesMissing` error variant and related handling
- adjust pairing logic now that the variant is unreachable
- remove the obsolete test

## Testing
- `cargo test` *(fails: encountered diff marker in `file_utils.rs`)*

------
https://chatgpt.com/codex/tasks/task_e_686ad029e2ec8322865751f4e8392f51