### PR TITLE
Fix duplicate detection during label parsing

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -21,15 +21,10 @@ pub enum ExportError {
     FailedToUnwrapLabelPath,
     #[error("Failed to copy file '{0}' to '{1}'.")]
     FailedToCopyFile(String, String),
-<<<<<<< HEAD
     #[error("Failed to read config: {0}")]
     ReadConfig(String),
     #[error("Failed to parse config: {0}")]
     ParseConfig(String),
-=======
-    #[error("Unable to write YOLO YAML file '{0}'.")]
-    WriteYaml(String),
->>>>>>> d5f8f38db09703cc0d2b505bc98688e51c43f07b
 }
 
 /// Handles writing a [`YoloProject`] to disk.
@@ -40,10 +35,6 @@ pub struct YoloProjectExporter {
 
 impl YoloProjectExporter {
     /// Write the given [`YoloProject`] to disk according to its configuration.
-    ///
-    /// The dataset is copied into the directory structure defined by
-    /// [`crate::Export::paths`]. Existing files are overwritten. Any errors
-    /// during file operations are reported via [`ExportError`].
     pub fn export(project: YoloProject) -> Result<(), ExportError> {
         let paths = &project.config.export.paths;
 
@@ -52,7 +43,7 @@ impl YoloProjectExporter {
         let project_name = &project.config.project_name;
         let classes = &project.config.export.class_map;
 
-        Self::create_yolo_yaml(project_name, paths, classes)?;
+        Self::create_yolo_yaml(project_name, paths, classes);
 
         let (train_pairs, validation_pairs, test_pairs) =
             Self::split_pairs(project.get_valid_pairs(), project.config.export.split);
@@ -154,11 +145,7 @@ impl YoloProjectExporter {
         Ok(())
     }
 
-    fn create_yolo_yaml(
-        project_name: &str,
-        paths: &Paths,
-        classes: &HashMap<isize, String>,
-    ) -> Result<(), ExportError> {
+    fn create_yolo_yaml(project_name: &str, paths: &Paths, classes: &HashMap<isize, String>) {
         let mut classes_vec: Vec<(isize, String)> =
             classes.iter().map(|(&k, v)| (k, v.clone())).collect();
 
@@ -187,15 +174,7 @@ names:
 "
         );
 
-<<<<<<< HEAD
         let yolo_yaml_path = PathBuf::from(&root_path).join(format!("{project_name}.yaml"));
         fs::write(yolo_yaml_path, yolo_yaml).unwrap();
-=======
-        let yolo_yaml_path = format!("{root_path}/{project_name}.yaml");
-        fs::write(&yolo_yaml_path, yolo_yaml)
-            .map_err(|_| ExportError::WriteYaml(yolo_yaml_path))?;
-
-        Ok(())
->>>>>>> d5f8f38db09703cc0d2b505bc98688e51c43f07b
     }
 }

--- a/src/file_utils.rs
+++ b/src/file_utils.rs
@@ -91,37 +91,7 @@ pub fn get_filepaths_for_extension(
         }
     }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-    // Ensure deterministic order of returned paths
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-
->>>>>>> 41a5c29104dc33c0f0f2a3a1576287e6710baaeb
-=======
-    // Ensure deterministic ordering
->>>>>>> c9cf85d60740a6510ca489f36753e559018a9dbe
-=======
->>>>>>> 4f08b15df24ace696343f6d3fd4485ad08bb764b
-=======
-    // Ensure deterministic ordering
->>>>>>> c3b6efd01ea4f59079e5734f0465ca98e4559444
-=======
-    // Ensure deterministic ordering
->>>>>>> f81ccc4939ee178da75b073df90b7d5c05d68f4f
-=======
-    // Ensure deterministic order of returned paths
->>>>>>> 0b309e9da26ac872d7ffa5dc0125e56dd2d7e65d
-=======
-    // Ensure deterministic order of returned paths
->>>>>>> d5f8f38db09703cc0d2b505bc98688e51c43f07b
-=======
     // Ensure deterministic ordering of returned paths
->>>>>>> 4f3b3d75592e0b37becbaae01f804963cc209459
     paths.sort_by(|a, b| a.path.cmp(&b.path));
 
     Ok(paths)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,27 +3,10 @@
 //! The crate scans directories for image and label files, pairs them,
 //! validates the labels and can export the result into the YOLO directory
 //! structure.  See [`YoloProject`] for the main entry point.
-<<<<<<< HEAD
-//!
-//! # Example
-//! ```no_run
-//! use std::fs;
-//! use yolo_io::{YoloProjectConfig, YoloProject, YoloDataQualityReport, YoloProjectExporter};
-//!
-//! let config = YoloProjectConfig::new("examples/config.yaml").unwrap();
-//! let project = YoloProject::new(&config).unwrap();
-//! if let Some(report) = YoloDataQualityReport::generate(project.clone()) {
-//!     fs::write("report.json", report).unwrap();
-//! }
-//! YoloProjectExporter::export(project).unwrap();
-//! ```
-#[macro_use]
-=======
->>>>>>> 4f3b3d75592e0b37becbaae01f804963cc209459
-mod report;
 mod export;
 mod file_utils;
 mod pairing;
+mod report;
 mod types;
 mod yolo_file;
 
@@ -57,10 +40,9 @@ pub struct YoloProjectData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// High level representation of a YOLO dataset project.
 ///
-/// Constructed from a [`YoloProjectConfig`], this struct contains the
-/// scan results and configuration for a dataset. Use [`YoloProject::new`]
-/// to load a project from disk and then inspect or export the validated
-/// pairs.
+/// The project is constructed from a [`YoloProjectConfig`] and holds
+/// both the configuration and the results from file pairing and
+/// validation stored in [`YoloProjectData`].
 pub struct YoloProject {
     /// Data produced when loading the project.
     pub data: YoloProjectData,
@@ -82,11 +64,10 @@ impl Default for YoloProject {
 }
 
 impl YoloProject {
-    /// Load a project from disk using the provided configuration.
+    /// Load a project using a [`YoloProjectConfig`].
     ///
-    /// The function scans the configured image and label directories,
+    /// This scans the configured image and label directories,
     /// pairs files with the same stem and validates each pair.
-    /// Returns an IO error if any of the directories cannot be read.
     pub fn new(config: &YoloProjectConfig) -> Result<Self, FileError> {
         let image_paths = get_filepaths_for_extension(
             &config.source_paths.images,

--- a/src/pairing.rs
+++ b/src/pairing.rs
@@ -6,6 +6,7 @@ use crate::types::{
 };
 use crate::YoloFile;
 
+/// Pair images and labels based on matching file stems.
 pub fn pair(
     file_metadata: FileMetadata,
     stems: Vec<String>,
@@ -15,96 +16,11 @@ pub fn pair(
     let mut pairs = Vec::new();
 
     for stem in stems {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> c3b6efd01ea4f59079e5734f0465ca98e4559444
-=======
->>>>>>> 4f3b3d75592e0b37becbaae01f804963cc209459
-        let image_paths_for_stem = image_filenames
-            .clone()
-            .into_iter()
-=======
         let mut image_paths_for_stem = image_filenames
             .iter()
->>>>>>> f81ccc4939ee178da75b073df90b7d5c05d68f4f
-=======
-        let mut image_paths_for_stem = image_filenames
-            .iter()
->>>>>>> 0b309e9da26ac872d7ffa5dc0125e56dd2d7e65d
             .filter(|image| image.key == *stem)
-            .map(|image| match image.clone().path.to_str() {
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
->>>>>>> 4f08b15df24ace696343f6d3fd4485ad08bb764b
-        let mut image_paths_for_stem = image_filenames
-            .clone()
-            .into_iter()
-            .filter(|image| image.key == *stem)
-<<<<<<< HEAD
             .map(|image| image.path.clone())
             .collect::<Vec<PathBuf>>();
-<<<<<<< HEAD
-        image_paths_for_stem.sort();
-        let mut image_paths_for_stem = image_paths_for_stem
-            .iter()
-            .map(|image| match image.to_str() {
->>>>>>> 41a5c29104dc33c0f0f2a3a1576287e6710baaeb
-=======
-        let image_paths_for_stem = image_filenames
-            .clone()
-            .into_iter()
-            .filter(|image| image.key == *stem)
-            .map(|image| match image.clone().path.to_str() {
->>>>>>> c9cf85d60740a6510ca489f36753e559018a9dbe
-=======
-            .map(|image| match image.clone().path.to_str() {
->>>>>>> 4f08b15df24ace696343f6d3fd4485ad08bb764b
-=======
->>>>>>> c3b6efd01ea4f59079e5734f0465ca98e4559444
-=======
-        let image_paths_for_stem = image_filenames
-            .clone()
-            .into_iter()
-            .filter(|image| image.key == *stem)
-            .map(|image| match image.clone().path.to_str() {
->>>>>>> d5f8f38db09703cc0d2b505bc98688e51c43f07b
-=======
->>>>>>> 4f3b3d75592e0b37becbaae01f804963cc209459
-                Some(path) => Ok(path.to_string()),
-                None => Err(()),
-            })
-            .collect::<Vec<Result<String, ()>>>();
-<<<<<<< HEAD
-
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 4f3b3d75592e0b37becbaae01f804963cc209459
-        let label_paths_for_stem = label_filenames
-            .clone()
-            .into_iter()
-            .filter(|label| label.key == *stem)
-            .map(|label| match label.clone().path.to_str() {
-<<<<<<< HEAD
-=======
-=======
->>>>>>> 4f08b15df24ace696343f6d3fd4485ad08bb764b
-=======
->>>>>>> f81ccc4939ee178da75b073df90b7d5c05d68f4f
-=======
         image_paths_for_stem.sort_by(|a, b| a.to_string_lossy().cmp(&b.to_string_lossy()));
 
         let mut image_paths_for_stem = image_paths_for_stem
@@ -114,7 +30,6 @@ pub fn pair(
                 None => Err(()),
             })
             .collect::<Vec<Result<String, ()>>>();
->>>>>>> 0b309e9da26ac872d7ffa5dc0125e56dd2d7e65d
         image_paths_for_stem.sort_by(|a, b| {
             let a_str = a.as_ref().map(|s| s.as_str()).unwrap_or("");
             let b_str = b.as_ref().map(|s| s.as_str()).unwrap_or("");
@@ -122,70 +37,10 @@ pub fn pair(
         });
 
         let mut label_paths_for_stem = label_filenames
-<<<<<<< HEAD
-<<<<<<< HEAD
-            .clone()
-            .into_iter()
-=======
             .iter()
->>>>>>> f81ccc4939ee178da75b073df90b7d5c05d68f4f
-=======
-            .iter()
->>>>>>> 0b309e9da26ac872d7ffa5dc0125e56dd2d7e65d
             .filter(|label| label.key == *stem)
-<<<<<<< HEAD
             .map(|label| label.path.clone())
             .collect::<Vec<PathBuf>>();
-<<<<<<< HEAD
-        label_paths_for_stem.sort();
-        let mut label_paths_for_stem = label_paths_for_stem
-            .iter()
-            .map(|label| match label.to_str() {
->>>>>>> 41a5c29104dc33c0f0f2a3a1576287e6710baaeb
-=======
-        let label_paths_for_stem = label_filenames
-            .clone()
-            .into_iter()
-            .filter(|label| label.key == *stem)
-            .map(|label| match label.clone().path.to_str() {
->>>>>>> c9cf85d60740a6510ca489f36753e559018a9dbe
-=======
-            .map(|label| match label.clone().path.to_str() {
->>>>>>> 4f08b15df24ace696343f6d3fd4485ad08bb764b
-=======
-        let label_paths_for_stem = label_filenames
-            .clone()
-            .into_iter()
-            .filter(|label| label.key == *stem)
-            .map(|label| match label.clone().path.to_str() {
->>>>>>> c3b6efd01ea4f59079e5734f0465ca98e4559444
-=======
-        let label_paths_for_stem = label_filenames
-            .clone()
-            .into_iter()
-            .filter(|label| label.key == *stem)
-            .map(|label| match label.clone().path.to_str() {
->>>>>>> d5f8f38db09703cc0d2b505bc98688e51c43f07b
-=======
->>>>>>> 4f3b3d75592e0b37becbaae01f804963cc209459
-                Some(path) => Ok(path.to_string()),
-                None => Err(()),
-            })
-            .collect::<Vec<Result<String, ()>>>();
-<<<<<<< HEAD
-
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
->>>>>>> 4f08b15df24ace696343f6d3fd4485ad08bb764b
-=======
->>>>>>> f81ccc4939ee178da75b073df90b7d5c05d68f4f
-=======
         label_paths_for_stem.sort_by(|a, b| a.to_string_lossy().cmp(&b.to_string_lossy()));
 
         let mut label_paths_for_stem = label_paths_for_stem
@@ -195,43 +50,14 @@ pub fn pair(
                 None => Err(()),
             })
             .collect::<Vec<Result<String, ()>>>();
->>>>>>> 0b309e9da26ac872d7ffa5dc0125e56dd2d7e65d
         label_paths_for_stem.sort_by(|a, b| {
             let a_str = a.as_ref().map(|s| s.as_str()).unwrap_or("");
             let b_str = b.as_ref().map(|s| s.as_str()).unwrap_or("");
             a_str.cmp(b_str)
         });
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
->>>>>>> 41a5c29104dc33c0f0f2a3a1576287e6710baaeb
-=======
->>>>>>> c9cf85d60740a6510ca489f36753e559018a9dbe
-        let (invalid_pairs, valid_label_paths) =
-            process_label_path(&file_metadata, label_paths_for_stem);
-=======
-=======
-        let (invalid_pairs, valid_label_paths) =
-            process_label_path(&file_metadata, label_paths_for_stem);
->>>>>>> c3b6efd01ea4f59079e5734f0465ca98e4559444
-=======
-=======
-=======
-        let (invalid_pairs, valid_label_paths) =
-            process_label_path(&file_metadata, label_paths_for_stem);
->>>>>>> d5f8f38db09703cc0d2b505bc98688e51c43f07b
 
         let (invalid_pairs, valid_label_paths) =
             process_label_path(&file_metadata, label_paths_for_stem);
->>>>>>> 0b309e9da26ac872d7ffa5dc0125e56dd2d7e65d
-
-        let (invalid_pairs, valid_label_paths) =
-            process_label_path(&file_metadata, label_paths_for_stem);
->>>>>>> f81ccc4939ee178da75b073df90b7d5c05d68f4f
-=======
-        let (invalid_pairs, valid_label_paths) =
-            process_label_path(&file_metadata, label_paths_for_stem);
->>>>>>> 4f3b3d75592e0b37becbaae01f804963cc209459
 
         let label_paths_for_stem = valid_label_paths
             .into_iter()
@@ -249,14 +75,21 @@ pub fn pair(
 
             match result {
                 PairingResult::Valid(pair) => match primary_pair {
-                    Some(ref primary_pair) => {
-                        pairs.push(PairingResult::Invalid(PairingError::Duplicate(
-                            DuplicateImageLabelPair {
+                    Some(ref primary) => {
+                        let error = if primary.label_file != pair.label_file {
+                            PairingError::DuplicateLabelMismatch(DuplicateImageLabelPair {
                                 name: stem.clone(),
-                                primary: primary_pair.clone(),
+                                primary: primary.clone(),
                                 duplicate: pair.clone(),
-                            },
-                        )));
+                            })
+                        } else {
+                            PairingError::Duplicate(DuplicateImageLabelPair {
+                                name: stem.clone(),
+                                primary: primary.clone(),
+                                duplicate: pair.clone(),
+                            })
+                        };
+                        pairs.push(PairingResult::Invalid(error));
                     }
                     None => {
                         primary_pair = Some(pair.clone());
@@ -274,13 +107,6 @@ pub fn pair(
 
     pairs
 }
-<<<<<<< HEAD
-
-<<<<<<< HEAD
-=======
->>>>>>> 0b309e9da26ac872d7ffa5dc0125e56dd2d7e65d
-=======
->>>>>>> d5f8f38db09703cc0d2b505bc98688e51c43f07b
 pub fn process_label_path(
     file_metadata: &FileMetadata,
     label_paths_for_stem: Vec<Result<String, ()>>,
@@ -310,6 +136,7 @@ pub fn process_label_path(
     (invalid_pairs, valid_paths)
 }
 
+/// Build a [`PairingResult`] from a potential image/label pair.
 pub fn evaluate_pair(
     stem: String,
     pair: EitherOrBoth<Result<String, ()>>,
@@ -337,7 +164,7 @@ pub fn evaluate_pair(
             (Err(_), Ok(label_path)) => {
                 PairingResult::Invalid(PairingError::ImageFileMissing(label_path))
             }
-            (Err(_), Err(_)) => unreachable!("both image and label paths missing after validation"),
+            (Err(_), Err(_)) => PairingResult::Invalid(PairingError::BothFilesMissing),
         },
         EitherOrBoth::Left(image_path) => match image_path {
             Ok(image_path) => PairingResult::Invalid(PairingError::LabelFileMissing(image_path)),

--- a/src/report.rs
+++ b/src/report.rs
@@ -83,6 +83,7 @@ impl YoloDataQualityReport {
             }
             PairingError::Duplicate(_) => String::from("DuplicateImageLabelPair"),
             PairingError::DuplicateLabelMismatch(_) => String::from("DuplicateImageLabelMismatch"),
+            PairingError::BothFilesMissing => String::from("BothFilesMissing"),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,9 +18,6 @@ pub struct Split {
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 /// Settings controlling dataset export.
-///
-/// These options determine where the processed dataset will be
-/// written and how duplicates and splits are handled.
 pub struct Export {
     /// Directory layout for the exported dataset.
     pub paths: Paths,
@@ -34,9 +31,6 @@ pub struct Export {
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 /// Collection of paths used during export.
-///
-/// The values are joined with the project root to form the final
-/// directory layout written by [`crate::YoloProjectExporter`].
 pub struct Paths {
     /// Root directory for exported data.
     pub root: String,
@@ -179,44 +173,11 @@ pub struct FileMetadata {
 
 /// Configuration for a YOLO project.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-/// Top level configuration for a [`crate::YoloProject`].
-///
-/// This structure mirrors the fields of the `config.yaml` file and is
-/// typically loaded using [`YoloProjectConfig::new`].
+/// Top level configuration for a [`YoloProject`].
 pub struct YoloProjectConfig {
     /// Location of images and labels to scan.
     pub source_paths: SourcePaths,
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-    /// Identifies the project format. Currently only "yolo" is supported but
-    /// this field is reserved for future project types.
-<<<<<<< HEAD
-=======
     /// Type of project, currently always "yolo".
->>>>>>> c9cf85d60740a6510ca489f36753e559018a9dbe
-=======
->>>>>>> 4f08b15df24ace696343f6d3fd4485ad08bb764b
-=======
-    /// Type of project, currently always "yolo".
->>>>>>> c3b6efd01ea4f59079e5734f0465ca98e4559444
-=======
-    /// Identifies the project format. Currently only "yolo" is supported,
-    /// but this field is reserved for future project types.
->>>>>>> f81ccc4939ee178da75b073df90b7d5c05d68f4f
-=======
-    /// Identifies the project format. Currently only "yolo" is supported but
-    /// this field is reserved for future project types.
->>>>>>> 0b309e9da26ac872d7ffa5dc0125e56dd2d7e65d
-=======
-    /// Identifies the project format. Currently only "yolo" is supported but
-    /// this field is reserved for future project types.
->>>>>>> d5f8f38db09703cc0d2b505bc98688e51c43f07b
-=======
-    /// Type of project, currently always "yolo".
->>>>>>> 4f3b3d75592e0b37becbaae01f804963cc209459
     pub r#type: String,
     /// Name of the project.
     pub project_name: String,
@@ -247,10 +208,9 @@ impl Default for YoloProjectConfig {
 impl YoloProjectConfig {
     /// Read a YAML configuration from disk.
     pub fn new(path: &str) -> Result<Self, ExportError> {
-        let data =
-            fs::read_to_string(path).map_err(|e| ExportError::ReadConfig(e.to_string()))?;
-        let config = serde_yml::from_str(&data)
-            .map_err(|e| ExportError::ParseConfig(e.to_string()))?;
+        let data = fs::read_to_string(path).map_err(|e| ExportError::ReadConfig(e.to_string()))?;
+        let config =
+            serde_yml::from_str(&data).map_err(|e| ExportError::ParseConfig(e.to_string()))?;
         Ok(config)
     }
 }
@@ -285,11 +245,9 @@ impl std::fmt::Display for DuplicateImageLabelPair {
 
 #[derive(Error, Clone, PartialEq, Debug, Serialize, Deserialize)]
 /// Reasons why a stem could not be paired.
-///
-/// These errors are produced during project loading when an image and
-/// label file cannot be matched or validated.
 pub enum PairingError {
     LabelFileError(YoloFileParseError),
+    BothFilesMissing,
     LabelFileMissing(String),
     LabelFileMissingUnableToUnwrapImagePath,
     ImageFileMissing(String),
@@ -304,6 +262,7 @@ impl std::fmt::Display for PairingError {
             PairingError::LabelFileError(error) => {
                 write!(f, "Label file error: {}", error)
             }
+            PairingError::BothFilesMissing => write!(f, "Both files missing"),
             PairingError::LabelFileMissing(path) => {
                 write!(f, "Label file missing: {}", path)
             }

--- a/tests/duplicate_testing.rs
+++ b/tests/duplicate_testing.rs
@@ -47,13 +47,14 @@ mod duplicate_tests {
         let valid_pairs = project.get_valid_pairs();
         let invalid_pairs = project.get_invalid_pairs();
 
-        println!("{:#?}", valid_pairs);
-        println!("{:#?}", invalid_pairs);
-
         let valid_pair = valid_pairs.into_iter().find(|pair| pair.name == "test1");
-        let invalid_pair = invalid_pairs
-            .into_iter()
-            .find(|pair| matches!(pair, yolo_io::PairingError::Duplicate(_)));
+        let invalid_pair = invalid_pairs.into_iter().find(|pair| {
+            matches!(
+                pair,
+                yolo_io::PairingError::Duplicate(_)
+                    | yolo_io::PairingError::DuplicateLabelMismatch(_)
+            )
+        });
 
         assert!(valid_pair.is_some());
         assert!(invalid_pair.is_some());
@@ -114,13 +115,16 @@ mod duplicate_tests {
         let valid_pairs = project.get_valid_pairs();
         let invalid_pairs = project.get_invalid_pairs();
 
-        println!("{:#?}", valid_pairs);
-        println!("{:#?}", invalid_pairs);
-
         let valid_pair = valid_pairs.into_iter().find(|pair| pair.name == file_key);
         let invalid_pairs = invalid_pairs
             .into_iter()
-            .filter(|pair| matches!(pair, yolo_io::PairingError::Duplicate(_)))
+            .filter(|pair| {
+                matches!(
+                    pair,
+                    yolo_io::PairingError::Duplicate(_)
+                        | yolo_io::PairingError::DuplicateLabelMismatch(_)
+                )
+            })
             .collect::<Vec<_>>();
 
         assert!(valid_pair.is_some());
@@ -128,42 +132,6 @@ mod duplicate_tests {
     }
 
     #[rstest]
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> c3b6efd01ea4f59079e5734f0465ca98e4559444
-=======
->>>>>>> 4f3b3d75592e0b37becbaae01f804963cc209459
-    fn test_duplicate_label_files_with_different_data(
-        mut create_yolo_project_config: YoloProjectConfig,
-        image_data: ImageBuffer<Rgb<u8>, Vec<u8>>,
-    ) {
-        let filename = "dup_different";
-        let this_test_directory = format!("{}/{}/", TEST_SANDBOX_DIR, filename);
-
-        let image_file = PathBuf::from(format!("{}/test.jpg", this_test_directory));
-        create_image_file(&image_file, &image_data);
-
-        let image_file_duplicate =
-            PathBuf::from(format!("{}/elsewhere/test.jpg", this_test_directory));
-        create_image_file(&image_file_duplicate, &image_data);
-
-        let label_file = PathBuf::from(format!("{}/test.txt", this_test_directory));
-        create_dir_and_write_file(&label_file, "0 0.5 0.5 0.5 0.5");
-
-        let label_file_duplicate =
-            PathBuf::from(format!("{}/elsewhere/test.txt", this_test_directory));
-        create_dir_and_write_file(&label_file_duplicate, "0 0.6 0.6 0.5 0.5");
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
->>>>>>> 0b309e9da26ac872d7ffa5dc0125e56dd2d7e65d
-=======
->>>>>>> d5f8f38db09703cc0d2b505bc98688e51c43f07b
     fn test_duplicate_pairs_with_different_labels(
         mut create_yolo_project_config: YoloProjectConfig,
         image_data: ImageBuffer<Rgb<u8>, Vec<u8>>,
@@ -182,72 +150,17 @@ mod duplicate_tests {
 
         let label_file_duplicate = PathBuf::from(format!("{}/else/test1.txt", this_test_directory));
         create_dir_and_write_file(&label_file_duplicate, "1 0.5 0.5 0.5 0.5");
-<<<<<<< HEAD
-<<<<<<< HEAD
->>>>>>> 4f08b15df24ace696343f6d3fd4485ad08bb764b
-=======
->>>>>>> c3b6efd01ea4f59079e5734f0465ca98e4559444
-=======
->>>>>>> 0b309e9da26ac872d7ffa5dc0125e56dd2d7e65d
-=======
->>>>>>> d5f8f38db09703cc0d2b505bc98688e51c43f07b
-=======
->>>>>>> 4f3b3d75592e0b37becbaae01f804963cc209459
 
         create_yolo_project_config.source_paths.images = this_test_directory.clone();
         create_yolo_project_config.source_paths.labels = this_test_directory.clone();
 
         let project = YoloProject::new(&create_yolo_project_config).unwrap();
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> c3b6efd01ea4f59079e5734f0465ca98e4559444
-=======
->>>>>>> 4f3b3d75592e0b37becbaae01f804963cc209459
-        let valid_pairs = project.get_valid_pairs();
-        let invalid_pairs = project.get_invalid_pairs();
-
-        let valid_pair = valid_pairs.into_iter().find(|pair| pair.name == "test");
-        let duplicate_error = invalid_pairs
-            .into_iter()
-            .find(|pair| matches!(pair, yolo_io::PairingError::Duplicate(_)));
-
-        assert!(valid_pair.is_some());
-        assert!(duplicate_error.is_some());
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
->>>>>>> 0b309e9da26ac872d7ffa5dc0125e56dd2d7e65d
         let invalid_pairs = project.get_invalid_pairs();
         let mismatch = invalid_pairs
             .into_iter()
             .find(|pair| matches!(pair, yolo_io::PairingError::DuplicateLabelMismatch(_)));
 
         assert!(mismatch.is_some());
-<<<<<<< HEAD
->>>>>>> 4f08b15df24ace696343f6d3fd4485ad08bb764b
-=======
->>>>>>> c3b6efd01ea4f59079e5734f0465ca98e4559444
-=======
->>>>>>> 0b309e9da26ac872d7ffa5dc0125e56dd2d7e65d
-=======
-        let invalid_pairs = project.get_invalid_pairs();
-        let mismatch = invalid_pairs.into_iter().find(|pair| {
-            matches!(
-                pair,
-                yolo_io::PairingError::DuplicateLabelMismatch(_)
-                    | yolo_io::PairingError::Duplicate(_)
-            )
-        });
-
-        assert!(mismatch.is_some());
->>>>>>> d5f8f38db09703cc0d2b505bc98688e51c43f07b
-=======
->>>>>>> 4f3b3d75592e0b37becbaae01f804963cc209459
     }
 }

--- a/tests/invalid_label_tests.rs
+++ b/tests/invalid_label_tests.rs
@@ -335,20 +335,7 @@ mod invalid_label_tests {
             panic!("Expected error");
         }
     }
-<<<<<<< HEAD
-<<<<<<< HEAD
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
->>>>>>> 4f08b15df24ace696343f6d3fd4485ad08bb764b
-=======
->>>>>>> 0b309e9da26ac872d7ffa5dc0125e56dd2d7e65d
-=======
->>>>>>> d5f8f38db09703cc0d2b505bc98688e51c43f07b
     #[test]
     fn test_yolo_file_new_allows_duplicates_when_tolerance_zero() {
         let filename = "tolerance_zero.txt";
@@ -365,20 +352,8 @@ mod invalid_label_tests {
         let yolo_file = YoloFile::new(&metadata, &path);
 
         assert!(yolo_file.is_ok());
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
     }
 
->>>>>>> c9cf85d60740a6510ca489f36753e559018a9dbe
-=======
-    }
-
->>>>>>> 0b309e9da26ac872d7ffa5dc0125e56dd2d7e65d
-=======
-    }
-
->>>>>>> d5f8f38db09703cc0d2b505bc98688e51c43f07b
     fn create_yolo_label_file_with_tolerance(
         filename: &str,
         classes: Vec<YoloClass>,
@@ -413,47 +388,9 @@ mod invalid_label_tests {
 
         let yolo_file = YoloFile::new(&metadata, &path);
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-        assert!(yolo_file.is_ok());
-    }
-
-    #[test]
-    fn test_yolo_file_new_allows_duplicates_when_tolerance_zero() {
-        let filename = "tolerance_zero.txt";
-        let classes_raw = vec![(0, "person")];
-        let classes = create_yolo_classes(classes_raw.clone());
-        let (mut metadata, path) = create_yolo_label_file(
-            filename,
-            classes,
-            "0 0.25 0.5 0.25 0.5\n0 0.25 0.5 0.25 0.5",
-        );
-
-        metadata.duplicate_tolerance = 0.0;
-
-        let yolo_file = YoloFile::new(&metadata, &path);
-
-        assert!(yolo_file.is_ok());
-=======
         assert!(matches!(
             yolo_file,
             Err(YoloFileParseError::DuplicateEntries(_))
         ));
-<<<<<<< HEAD
-<<<<<<< HEAD
->>>>>>> 41a5c29104dc33c0f0f2a3a1576287e6710baaeb
-=======
->>>>>>> c9cf85d60740a6510ca489f36753e559018a9dbe
-=======
->>>>>>> 4f08b15df24ace696343f6d3fd4485ad08bb764b
-=======
->>>>>>> 0b309e9da26ac872d7ffa5dc0125e56dd2d7e65d
-=======
-        assert!(yolo_file.is_ok());
->>>>>>> d5f8f38db09703cc0d2b505bc98688e51c43f07b
     }
-=======
->>>>>>> c3b6efd01ea4f59079e5734f0465ca98e4559444
-=======
->>>>>>> 4f3b3d75592e0b37becbaae01f804963cc209459
 }

--- a/tests/pairing_tests.rs
+++ b/tests/pairing_tests.rs
@@ -158,17 +158,35 @@ mod pairing_tests {
     }
 
     #[rstest]
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> c3b6efd01ea4f59079e5734f0465ca98e4559444
-=======
->>>>>>> 0b309e9da26ac872d7ffa5dc0125e56dd2d7e65d
-=======
->>>>>>> 4f3b3d75592e0b37becbaae01f804963cc209459
+    fn test_project_validation_produces_one_invalid_pair_for_no_image_no_label(
+        mut create_yolo_project_config: YoloProjectConfig,
+    ) {
+        // THIS ERROR IS IMPOSSIBLE TO TRIGGER
+        let filename = "five";
+        let this_test_directory = format!("{}/{}/", TEST_SANDBOX_DIR, filename);
+
+        fs::create_dir_all(&this_test_directory).expect("Unable to create directory");
+
+        create_yolo_project_config.source_paths.images = this_test_directory.clone();
+        create_yolo_project_config.source_paths.labels = this_test_directory.clone();
+
+        let project =
+            YoloProject::new(&create_yolo_project_config).expect("Unable to create project");
+
+        let valid_pairs = project.get_valid_pairs();
+        let valid_pair = valid_pairs.into_iter().find(|pair| pair.name == "test5");
+
+        let invalid_pairs = project.get_invalid_pairs();
+
+        let invalid_pair = invalid_pairs
+            .into_iter()
+            .find(|pair| matches!(pair, yolo_io::PairingError::BothFilesMissing));
+
+        assert!(valid_pair.is_none());
+        assert!(invalid_pair.is_none());
+    }
+
+    #[rstest]
     fn test_pairing_with_mixed_case_extensions(
         image_data: ImageBuffer<Rgb<u8>, Vec<u8>>,
         mut create_yolo_project_config: YoloProjectConfig,
@@ -180,40 +198,6 @@ mod pairing_tests {
         create_image_file(&image_file, &image_data);
 
         let label_file = PathBuf::from(format!("{}/testMiXeD.TxT", this_test_directory));
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-
->>>>>>> 41a5c29104dc33c0f0f2a3a1576287e6710baaeb
-=======
->>>>>>> c9cf85d60740a6510ca489f36753e559018a9dbe
-=======
-=======
->>>>>>> d5f8f38db09703cc0d2b505bc98688e51c43f07b
-    fn test_project_validation_handles_mixed_case_extensions(
-        image_data: ImageBuffer<Rgb<u8>, Vec<u8>>,
-        mut create_yolo_project_config: YoloProjectConfig,
-    ) {
-        let filename = "mixed_case";
-        let this_test_directory = format!("{}/{}/", TEST_SANDBOX_DIR, filename);
-
-        let image_file = PathBuf::from(format!("{}/test1.JpG", this_test_directory));
-        create_image_file(&image_file, &image_data);
-
-        let label_file = PathBuf::from(format!("{}/test1.TxT", this_test_directory));
-<<<<<<< HEAD
->>>>>>> 4f08b15df24ace696343f6d3fd4485ad08bb764b
-=======
->>>>>>> c3b6efd01ea4f59079e5734f0465ca98e4559444
-=======
->>>>>>> 0b309e9da26ac872d7ffa5dc0125e56dd2d7e65d
-=======
->>>>>>> d5f8f38db09703cc0d2b505bc98688e51c43f07b
-=======
->>>>>>> 4f3b3d75592e0b37becbaae01f804963cc209459
         create_dir_and_write_file(&label_file, "0 0.5 0.5 0.5 0.5");
 
         create_yolo_project_config.source_paths.images = this_test_directory.clone();
@@ -223,38 +207,9 @@ mod pairing_tests {
             YoloProject::new(&create_yolo_project_config).expect("Unable to create project");
 
         let valid_pairs = project.get_valid_pairs();
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
         let valid_pair = valid_pairs
             .into_iter()
             .find(|pair| pair.name == "testMiXeD");
-=======
-
-        let valid_pair = valid_pairs.into_iter().find(|pair| pair.name == "test1");
->>>>>>> 4f08b15df24ace696343f6d3fd4485ad08bb764b
-=======
-=======
->>>>>>> 4f3b3d75592e0b37becbaae01f804963cc209459
-
-        let valid_pair = valid_pairs
-            .into_iter()
-            .find(|pair| pair.name == "testMiXeD");
-<<<<<<< HEAD
->>>>>>> c3b6efd01ea4f59079e5734f0465ca98e4559444
-=======
-        let valid_pair = valid_pairs
-            .into_iter()
-            .find(|pair| pair.name == "testMiXeD");
->>>>>>> 0b309e9da26ac872d7ffa5dc0125e56dd2d7e65d
-=======
-
-        let valid_pair = valid_pairs.into_iter().find(|pair| pair.name == "test1");
->>>>>>> d5f8f38db09703cc0d2b505bc98688e51c43f07b
-=======
->>>>>>> 4f3b3d75592e0b37becbaae01f804963cc209459
 
         assert!(valid_pair.is_some());
     }


### PR DESCRIPTION
## Summary
- resolve merge remnants across repo
- check for duplicate bounding boxes as we parse labels
- handle `BothFilesMissing` report variant
- restore invalid label tests

## Testing
- `cargo fmt`
- `cargo test --no-run`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686ad5157c888322a38b28a10ce90117