### PR TITLE
Fix duplicate match arm

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -80,7 +80,6 @@ impl YoloDataQualityReport {
             }
             PairingError::Duplicate(_) => String::from("DuplicateImageLabelPair"),
             PairingError::DuplicateLabelMismatch(_) => String::from("DuplicateImageLabelMismatch"),
-            PairingError::BothFilesMissing => String::from("BothFilesMissing"),
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove duplicate `PairingError::BothFilesMissing` arm in `get_source_name`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686aeecce9388322a3c451d67e9e17fc