### PR TITLE
Add report generation binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde_json = "1.0.129"
 serde_yml = "0.0.12"
 thiserror = "1.0"
 log = "0.4"
+clap = { version = "4.4.18", features = ["derive"] }
 
 [dev-dependencies]
 image = "0.25.4" # https://docs.rs/image/latest/image/

--- a/src/bin/report.rs
+++ b/src/bin/report.rs
@@ -1,0 +1,70 @@
+use clap::{Parser, ValueEnum};
+use std::path::PathBuf;
+use yolo_io::{YoloDataQualityReport, YoloProject, YoloProjectConfig};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about = "Generate a data quality report")]
+pub struct Cli {
+    /// Path to the YAML configuration file
+    #[arg(short, long)]
+    config: PathBuf,
+
+    /// Output file path
+    #[arg(short, long, default_value = "report.json")]
+    output: PathBuf,
+
+    /// Output format of the report
+    #[arg(short, long, value_enum, default_value_t = Format::Json)]
+    format: Format,
+}
+
+#[derive(ValueEnum, Clone, Debug, PartialEq)]
+pub enum Format {
+    Json,
+    Yaml,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+
+    let config = YoloProjectConfig::new(cli.config.to_str().unwrap())?;
+    let project = YoloProject::new(&config)?;
+
+    if let Some(report_json) = YoloDataQualityReport::generate(project) {
+        let data = match cli.format {
+            Format::Json => report_json,
+            Format::Yaml => {
+                let value: serde_json::Value = serde_json::from_str(&report_json)?;
+                serde_yml::to_string(&value)?
+            }
+        };
+
+        std::fs::write(cli.output, data)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_required_args() {
+        let args = ["test", "--config", "path/to/config.yaml"];
+        let cli = Cli::try_parse_from(args).expect("Failed to parse args");
+        assert_eq!(cli.config, PathBuf::from("path/to/config.yaml"));
+        assert_eq!(cli.output, PathBuf::from("report.json"));
+        assert_eq!(cli.format, Format::Json);
+    }
+
+    #[test]
+    fn parses_custom_output_and_format() {
+        let args = [
+            "test", "--config", "c.yaml", "--output", "out.yml", "--format", "yaml",
+        ];
+        let cli = Cli::try_parse_from(args).expect("Failed to parse args");
+        assert_eq!(cli.output, PathBuf::from("out.yml"));
+        assert_eq!(cli.format, Format::Yaml);
+    }
+}


### PR DESCRIPTION
## Summary
- add `clap` dependency
- implement `src/bin/report.rs` to generate data quality reports in JSON or YAML
- provide unit tests for argument parsing

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686aeed9638883228dd6cd7b86da4047