### PR TITLE
Allow YoloProjectConfig::new to take any Path

### DIFF
--- a/src/bin/report.rs
+++ b/src/bin/report.rs
@@ -27,7 +27,7 @@ pub enum Format {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
-    let config = YoloProjectConfig::new(cli.config.to_str().unwrap())?;
+    let config = YoloProjectConfig::new(&cli.config)?;
     let project = YoloProject::new(&config)?;
 
     if let Some(report_json) = YoloDataQualityReport::generate(project) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,9 @@
 use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
-use std::{fs, path::PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 use thiserror::Error;
 
 use crate::{ExportError, YoloFile, YoloFileParseError};
@@ -207,8 +210,9 @@ impl Default for YoloProjectConfig {
 
 impl YoloProjectConfig {
     /// Read a YAML configuration from disk.
-    pub fn new(path: &str) -> Result<Self, ExportError> {
-        let data = fs::read_to_string(path).map_err(|e| ExportError::ReadConfig(e.to_string()))?;
+    pub fn new(path: impl AsRef<Path>) -> Result<Self, ExportError> {
+        let data = fs::read_to_string(path.as_ref())
+            .map_err(|e| ExportError::ReadConfig(e.to_string()))?;
         let config =
             serde_yml::from_str(&data).map_err(|e| ExportError::ParseConfig(e.to_string()))?;
         Ok(config)


### PR DESCRIPTION
## Summary
- load config files using a generic path argument
- call YoloProjectConfig::new with a PathBuf in `yoloio-report`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686af65f53188322a656bb02224be855