### PR TITLE
Fix unused imports and parameters in tests

### DIFF
--- a/tests/invalid_label_tests.rs
+++ b/tests/invalid_label_tests.rs
@@ -3,12 +3,9 @@ mod common;
 #[cfg(test)]
 mod invalid_label_tests {
     use rstest::rstest;
-    use std::path::PathBuf;
 
     use crate::common::TEST_SANDBOX_DIR;
-    use yolo_io::{
-        FileMetadata, YoloClass, YoloFile, YoloFileParseError, YoloFileParseErrorDetails,
-    };
+    use yolo_io::{FileMetadata, YoloClass, YoloFile, YoloFileParseError};
 
     fn create_yolo_classes(classes: Vec<(isize, &str)>) -> Vec<YoloClass> {
         classes

--- a/tests/report_tests.rs
+++ b/tests/report_tests.rs
@@ -26,7 +26,7 @@ mod report_tests {
 
     #[rstest]
     fn test_generate_report_with_label_file_error(
-        mut create_yolo_project_config: yolo_io::YoloProjectConfig,
+        _create_yolo_project_config: yolo_io::YoloProjectConfig,
     ) {
         let details = YoloFileParseErrorDetails {
             path: "label.txt".to_string(),
@@ -131,7 +131,7 @@ mod report_tests {
 
     #[rstest]
     fn test_generate_yaml_report_with_label_file_missing(
-        mut create_yolo_project_config: yolo_io::YoloProjectConfig,
+        _create_yolo_project_config: yolo_io::YoloProjectConfig,
     ) {
         let pairing_error = PairingError::LabelFileMissing("label.txt".to_string());
         let project = create_test_project(vec![PairingResult::Invalid(pairing_error.clone())]);


### PR DESCRIPTION
## Summary
- remove unused imports from `invalid_label_tests`
- underscore unused rstest fixture parameters in `report_tests`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686af6611768832291c7b761b0df9f0f