### PR TITLE
Use generate_yaml for YAML reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,11 @@ if let Some(report) = YoloDataQualityReport::generate(project.clone()) {
 }
 ```
 
-To create a YAML version, deserialize the JSON into `DataQualityItem` values and
-re-serialize with `serde_yml`:
+To create a YAML version, call `YoloDataQualityReport::generate_yaml`:
 
 ```rust
-use serde_yml;
-use yolo_io::*;
-
-if let Some(json) = YoloDataQualityReport::generate(project.clone()) {
-    let items: Vec<DataQualityItem> = serde_json::from_str(&json).unwrap();
-    let yaml = serde_yml::to_string(&items).unwrap();
+// from examples/basic.rs
+if let Some(yaml) = YoloDataQualityReport::generate_yaml(project.clone()) {
     fs::write("report.yaml", yaml).expect("Unable to write YAML report");
 }
 ```

--- a/src/bin/report.rs
+++ b/src/bin/report.rs
@@ -30,16 +30,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = YoloProjectConfig::new(cli.config.to_str().unwrap())?;
     let project = YoloProject::new(&config)?;
 
-    if let Some(report_json) = YoloDataQualityReport::generate(project) {
-        let data = match cli.format {
-            Format::Json => report_json,
-            Format::Yaml => {
-                let value: serde_json::Value = serde_json::from_str(&report_json)?;
-                serde_yml::to_string(&value)?
-            }
-        };
-
-        std::fs::write(cli.output, data)?;
+    if cli.format == Format::Yaml {
+        if let Some(report_yaml) = YoloDataQualityReport::generate_yaml(project) {
+            std::fs::write(cli.output, report_yaml)?;
+        }
+    } else if let Some(report_json) = YoloDataQualityReport::generate(project) {
+        std::fs::write(cli.output, report_json)?;
     }
 
     Ok(())

--- a/tests/invalid_label_tests.rs
+++ b/tests/invalid_label_tests.rs
@@ -3,12 +3,9 @@ mod common;
 #[cfg(test)]
 mod invalid_label_tests {
     use rstest::rstest;
-    use std::path::PathBuf;
 
     use crate::common::TEST_SANDBOX_DIR;
-    use yolo_io::{
-        FileMetadata, YoloClass, YoloFile, YoloFileParseError, YoloFileParseErrorDetails,
-    };
+    use yolo_io::{FileMetadata, YoloClass, YoloFile, YoloFileParseError};
 
     fn create_yolo_classes(classes: Vec<(isize, &str)>) -> Vec<YoloClass> {
         classes

--- a/tests/report_tests.rs
+++ b/tests/report_tests.rs
@@ -26,7 +26,7 @@ mod report_tests {
 
     #[rstest]
     fn test_generate_report_with_label_file_error(
-        mut create_yolo_project_config: yolo_io::YoloProjectConfig,
+        _create_yolo_project_config: yolo_io::YoloProjectConfig,
     ) {
         let details = YoloFileParseErrorDetails {
             path: "label.txt".to_string(),
@@ -131,7 +131,7 @@ mod report_tests {
 
     #[rstest]
     fn test_generate_yaml_report_with_label_file_missing(
-        mut create_yolo_project_config: yolo_io::YoloProjectConfig,
+        _create_yolo_project_config: yolo_io::YoloProjectConfig,
     ) {
         let pairing_error = PairingError::LabelFileMissing("label.txt".to_string());
         let project = create_test_project(vec![PairingResult::Invalid(pairing_error.clone())]);


### PR DESCRIPTION
## Summary
- switch CLI to call `YoloDataQualityReport::generate_yaml`
- update README instructions for YAML output
- fix clippy warnings in tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686af66923748322ad99f55eda4501f3