### PR TITLE
Improve docs and clean tests

### DIFF
--- a/src/pairing.rs
+++ b/src/pairing.rs
@@ -107,6 +107,13 @@ pub fn pair(
 
     pairs
 }
+
+/// Validate the label paths associated with a single file stem.
+///
+/// Each path is parsed to ensure the label file contents are valid
+/// according to the provided [`FileMetadata`]. Any parsing failures
+/// are returned as [`PairingResult::Invalid`] while successful paths
+/// are collected for pairing with images.
 pub fn process_label_path(
     file_metadata: &FileMetadata,
     label_paths_for_stem: Vec<Result<String, ()>>,

--- a/tests/invalid_label_tests.rs
+++ b/tests/invalid_label_tests.rs
@@ -3,12 +3,9 @@ mod common;
 #[cfg(test)]
 mod invalid_label_tests {
     use rstest::rstest;
-    use std::path::PathBuf;
 
     use crate::common::TEST_SANDBOX_DIR;
-    use yolo_io::{
-        FileMetadata, YoloClass, YoloFile, YoloFileParseError, YoloFileParseErrorDetails,
-    };
+    use yolo_io::{FileMetadata, YoloClass, YoloFile, YoloFileParseError};
 
     fn create_yolo_classes(classes: Vec<(isize, &str)>) -> Vec<YoloClass> {
         classes

--- a/tests/report_tests.rs
+++ b/tests/report_tests.rs
@@ -26,7 +26,7 @@ mod report_tests {
 
     #[rstest]
     fn test_generate_report_with_label_file_error(
-        mut create_yolo_project_config: yolo_io::YoloProjectConfig,
+        _create_yolo_project_config: yolo_io::YoloProjectConfig,
     ) {
         let details = YoloFileParseErrorDetails {
             path: "label.txt".to_string(),
@@ -131,7 +131,7 @@ mod report_tests {
 
     #[rstest]
     fn test_generate_yaml_report_with_label_file_missing(
-        mut create_yolo_project_config: yolo_io::YoloProjectConfig,
+        _create_yolo_project_config: yolo_io::YoloProjectConfig,
     ) {
         let pairing_error = PairingError::LabelFileMissing("label.txt".to_string());
         let project = create_test_project(vec![PairingResult::Invalid(pairing_error.clone())]);


### PR DESCRIPTION
## Summary
- document `process_label_path` function
- clean imports in `invalid_label_tests`
- suppress unused fixture warnings in report tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686af670152c8322be7736eb71ee0942