### PR TITLE
Fix unused test parameter warnings

### DIFF
--- a/tests/report_tests.rs
+++ b/tests/report_tests.rs
@@ -25,9 +25,7 @@ mod report_tests {
     }
 
     #[rstest]
-    fn test_generate_report_with_label_file_error(
-        _create_yolo_project_config: yolo_io::YoloProjectConfig,
-    ) {
+    fn test_generate_report_with_label_file_error() {
         let details = YoloFileParseErrorDetails {
             path: "label.txt".to_string(),
             class: None,
@@ -130,9 +128,7 @@ mod report_tests {
     }
 
     #[rstest]
-    fn test_generate_yaml_report_with_label_file_missing(
-        _create_yolo_project_config: yolo_io::YoloProjectConfig,
-    ) {
+    fn test_generate_yaml_report_with_label_file_missing() {
         let pairing_error = PairingError::LabelFileMissing("label.txt".to_string());
         let project = create_test_project(vec![PairingResult::Invalid(pairing_error.clone())]);
 


### PR DESCRIPTION
## Summary
- remove unused `create_yolo_project_config` parameters from `report_tests`
- confirm no stray imports in `invalid_label_tests`

## Testing
- `cargo test --no-run`


------
https://chatgpt.com/codex/tasks/task_e_686afc0387748322b197bde679df8cc1