### PR TITLE
Accept Path references for config

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -3,7 +3,8 @@ use yolo_io::*;
 
 fn main() {
     // Load the project configuration from disk
-    let config = YoloProjectConfig::new("examples/config.yaml").expect("Failed to load config");
+    let config = YoloProjectConfig::new(std::path::Path::new("examples/config.yaml"))
+        .expect("Failed to load config");
 
     // Build a project using the configuration
     let project = YoloProject::new(&config).expect("Failed to create project");

--- a/src/bin/report.rs
+++ b/src/bin/report.rs
@@ -27,7 +27,7 @@ pub enum Format {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
-    let config = YoloProjectConfig::new(&cli.config)?;
+    let config = YoloProjectConfig::new(cli.config.as_path())?;
     let project = YoloProject::new(&config)?;
 
     match cli.format {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,6 @@
 use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::{fs, path::PathBuf};
 use thiserror::Error;
 
 use crate::{ExportError, YoloFile, YoloFileParseError};
@@ -210,7 +207,7 @@ impl Default for YoloProjectConfig {
 
 impl YoloProjectConfig {
     /// Read a YAML configuration from disk.
-    pub fn new(path: impl AsRef<Path>) -> Result<Self, ExportError> {
+    pub fn new(path: impl AsRef<std::path::Path>) -> Result<Self, ExportError> {
         let data = fs::read_to_string(path.as_ref())
             .map_err(|e| ExportError::ReadConfig(e.to_string()))?;
         let config =

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -4,7 +4,7 @@ mod config_tests {
 
     #[test]
     fn test_invalid_config_path_returns_error() {
-        let result = YoloProjectConfig::new("tests/does_not_exist.yaml");
+        let result = YoloProjectConfig::new(std::path::Path::new("tests/does_not_exist.yaml"));
         assert!(matches!(result, Err(ExportError::ReadConfig(_))));
     }
 }


### PR DESCRIPTION
## Summary
- update `YoloProjectConfig::new` to take `impl AsRef<std::path::Path>`
- simplify call sites to pass `Path` directly

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686afc0037b483229f065fce479cc54d