### PR TITLE
Handle missing file when parsing

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -91,6 +91,9 @@ impl YoloDataQualityReport {
                 YoloFileParseError::FailedToGetFileStem(_) => {
                     String::from("YoloFileParseError::FailedToGetFileStem")
                 }
+                YoloFileParseError::FailedToReadFile(_) => {
+                    String::from("YoloFileParseError::FailedToReadFile")
+                }
             },
             PairingError::BothFilesMissing => String::from("BothFilesMissing"),
             PairingError::LabelFileMissing(_) => String::from("LabelFileMissing"),

--- a/tests/yolo_file_tests.rs
+++ b/tests/yolo_file_tests.rs
@@ -1,0 +1,27 @@
+mod common;
+
+#[cfg(test)]
+mod yolo_file_tests {
+    use crate::common::TEST_SANDBOX_DIR;
+    use yolo_io::{FileMetadata, YoloClass, YoloFile, YoloFileParseError};
+
+    #[test]
+    fn test_yolo_file_new_nonexistent_path_returns_error() {
+        let classes = vec![YoloClass {
+            id: 0,
+            name: "person".to_string(),
+        }];
+        let metadata = FileMetadata {
+            classes,
+            duplicate_tolerance: 0.01,
+        };
+        let path = format!("{}/missing.txt", TEST_SANDBOX_DIR);
+
+        let result = YoloFile::new(&metadata, &path);
+
+        assert!(matches!(
+            result,
+            Err(YoloFileParseError::FailedToReadFile(_))
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
- add `FailedToReadFile` error variant for failures when reading
- propagate file read failures in `YoloFile::new`
- handle new error in `report` module
- test error path for missing files

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686bc50e76d08322ada38b10c7ab8cc5