### PR TITLE
Use PathBuf for dataset paths

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -2,7 +2,10 @@ use hashbrown::HashMap;
 use log::debug;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
-use std::{fs, path::PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use thiserror::Error;
 
@@ -59,23 +62,23 @@ impl YoloProjectExporter {
         let (train_pairs, validation_pairs, test_pairs) =
             Self::split_pairs(project.get_valid_pairs(), project.config.export.split);
 
-        let test_image_path = &paths.get_test_images_path();
-        let test_label_path = &paths.get_test_label_images_path();
+        let test_image_path = paths.get_test_images_path();
+        let test_label_path = paths.get_test_label_images_path();
 
-        let train_image_path = &paths.get_train_images_path();
-        let train_label_path = &paths.get_train_label_images_path();
+        let train_image_path = paths.get_train_images_path();
+        let train_label_path = paths.get_train_label_images_path();
 
-        let val_image_path = &paths.get_validation_images_path();
-        let val_label_path = &paths.get_validation_label_images_path();
+        let val_image_path = paths.get_validation_images_path();
+        let val_label_path = paths.get_validation_label_images_path();
 
-        let splits: Vec<(&str, &str, Vec<ImageLabelPair>)> = vec![
+        let splits: Vec<(PathBuf, PathBuf, Vec<ImageLabelPair>)> = vec![
             (test_image_path, test_label_path, test_pairs),
             (train_image_path, train_label_path, train_pairs),
             (val_image_path, val_label_path, validation_pairs),
         ];
 
         for (images_path, labels_path, pairs) in splits {
-            Self::copy_files(images_path, labels_path, pairs)?;
+            Self::copy_files(&images_path, &labels_path, pairs)?;
         }
 
         Ok(())
@@ -105,8 +108,8 @@ impl YoloProjectExporter {
     }
 
     fn copy_files(
-        export_images_path: &str,
-        export_labels_path: &str,
+        export_images_path: &Path,
+        export_labels_path: &Path,
         pairs: Vec<ImageLabelPair>,
     ) -> Result<(), ExportError> {
         for pair in pairs {
@@ -132,11 +135,11 @@ impl YoloProjectExporter {
                 .and_then(|e| e.to_str())
                 .unwrap_or("");
 
-            let new_image_path = PathBuf::from(export_images_path)
-                .join(PathBuf::from(&pair.name).with_extension(image_ext));
+            let new_image_path =
+                export_images_path.join(PathBuf::from(&pair.name).with_extension(image_ext));
 
-            let new_label_path = PathBuf::from(export_labels_path)
-                .join(PathBuf::from(&pair.name).with_extension(label_ext));
+            let new_label_path =
+                export_labels_path.join(PathBuf::from(&pair.name).with_extension(label_ext));
 
             fs::copy(&image_path, &new_image_path).map_err(|_| {
                 ExportError::FailedToCopyFile(
@@ -179,17 +182,22 @@ impl YoloProjectExporter {
 
         let yolo_yaml = format!(
             "# Generate by yolo_io - https://github.com/Ladvien/yolo_io
-path: {root_path}
-train: {train_path}
-val: {val_path}
-test: {test_path}
+path: {}
+train: {}
+val: {}
+test: {}
 
 names:
-{classes_as_yaml}
-"
+{}
+",
+            root_path.to_string_lossy(),
+            train_path,
+            val_path,
+            test_path,
+            classes_as_yaml
         );
 
-        let yolo_yaml_path = PathBuf::from(&root_path).join(format!("{project_name}.yaml"));
+        let yolo_yaml_path = root_path.join(format!("{project_name}.yaml"));
         fs::write(&yolo_yaml_path, yolo_yaml)
             .map_err(|_| ExportError::WriteFile(yolo_yaml_path.to_string_lossy().into()))?;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -33,74 +33,79 @@ pub struct Export {
 /// Collection of paths used during export.
 pub struct Paths {
     /// Root directory for exported data.
-    pub root: String,
+    pub root: PathBuf,
     /// Sub directory used for training data.
-    pub train: String,
+    pub train: PathBuf,
     /// Sub directory used for validation data.
-    pub validation: String,
+    pub validation: PathBuf,
     /// Sub directory used for test data.
-    pub test: String,
+    pub test: PathBuf,
 }
 
 impl Paths {
     /// Create a new set of export paths.
-    pub fn new(root: &str, train: &str, validation: &str, test: &str) -> Self {
+    pub fn new(
+        root: impl Into<PathBuf>,
+        train: impl Into<PathBuf>,
+        validation: impl Into<PathBuf>,
+        test: impl Into<PathBuf>,
+    ) -> Self {
         Paths {
-            root: root.to_string(),
-            train: train.to_string(),
-            validation: validation.to_string(),
-            test: test.to_string(),
+            root: root.into(),
+            train: train.into(),
+            validation: validation.into(),
+            test: test.into(),
         }
     }
 
     /// Root path used for export.
-    pub fn get_root(&self) -> String {
+    pub fn get_root(&self) -> PathBuf {
         self.root.clone()
     }
 
     /// Path to the training images directory.
-    pub fn get_train_images_path(&self) -> String {
-        format!("{}/train/images", self.root).replace("//", "/")
+    pub fn get_train_images_path(&self) -> PathBuf {
+        self.root.join(&self.train).join("images")
     }
 
     /// Path to the training labels directory.
-    pub fn get_train_label_images_path(&self) -> String {
-        format!("{}/train/labels", self.root).replace("//", "/")
+    pub fn get_train_label_images_path(&self) -> PathBuf {
+        self.root.join(&self.train).join("labels")
     }
 
     /// Path to the validation images directory.
-    pub fn get_validation_images_path(&self) -> String {
-        format!("{}/validation/images", self.root).replace("//", "/")
+    pub fn get_validation_images_path(&self) -> PathBuf {
+        self.root.join(&self.validation).join("images")
     }
 
     /// Path to the validation labels directory.
-    pub fn get_validation_label_images_path(&self) -> String {
-        format!("{}/validation/labels", self.root).replace("//", "/")
+    pub fn get_validation_label_images_path(&self) -> PathBuf {
+        self.root.join(&self.validation).join("labels")
     }
 
     /// Path to the test images directory.
-    pub fn get_test_images_path(&self) -> String {
-        format!("{}/test/images", self.root).replace("//", "/")
+    pub fn get_test_images_path(&self) -> PathBuf {
+        self.root.join(&self.test).join("images")
     }
 
     /// Path to the test labels directory.
-    pub fn get_test_label_images_path(&self) -> String {
-        format!("{}/test/labels", self.root).replace("//", "/")
+    pub fn get_test_label_images_path(&self) -> PathBuf {
+        self.root.join(&self.test).join("labels")
     }
 
     /// Directory stem used for training data.
     pub fn get_train_stem(&self) -> String {
-        self.train.clone()
+        self.train.to_string_lossy().into_owned()
     }
 
     /// Directory stem used for validation data.
     pub fn get_validation_stem(&self) -> String {
-        self.validation.clone()
+        self.validation.to_string_lossy().into_owned()
     }
 
     /// Directory stem used for test data.
     pub fn get_test_stem(&self) -> String {
-        self.test.clone()
+        self.test.to_string_lossy().into_owned()
     }
 
     /// Create the directory structure on disk.
@@ -116,8 +121,10 @@ impl Paths {
         ];
 
         for path in paths_to_create {
-            if fs::create_dir_all(path.clone()).is_err() {
-                return Err(ExportError::UnableToCreateDirectory(path));
+            if fs::create_dir_all(&path).is_err() {
+                return Err(ExportError::UnableToCreateDirectory(
+                    path.to_string_lossy().into_owned(),
+                ));
             }
         }
 
@@ -128,10 +135,10 @@ impl Paths {
 impl Default for Paths {
     fn default() -> Self {
         Self {
-            root: "export".to_string(),
-            train: "train".to_string(),
-            validation: "validation".to_string(),
-            test: "test".to_string(),
+            root: PathBuf::from("export"),
+            train: PathBuf::from("train"),
+            validation: PathBuf::from("validation"),
+            test: PathBuf::from("test"),
         }
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,7 @@
-use std::{fs, path::Path};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use hashbrown::HashMap;
 use image::{ImageBuffer, Rgb};
@@ -94,10 +97,10 @@ pub fn create_yolo_project_config() -> YoloProjectConfig {
         project_name: String::from("test_project"),
         export: Export {
             paths: Paths {
-                train: String::from("train/"),
-                validation: String::from("validation/"),
-                test: String::from("test/"),
-                root: String::from("tests/sandbox/export/"),
+                train: PathBuf::from("train/"),
+                validation: PathBuf::from("validation/"),
+                test: PathBuf::from("test/"),
+                root: PathBuf::from("tests/sandbox/export/"),
             },
             class_map,
             duplicate_tolerance: 0.01,

--- a/tests/export_tests.rs
+++ b/tests/export_tests.rs
@@ -3,7 +3,7 @@ mod common;
 #[cfg(test)]
 mod tests {
 
-    use std::fs;
+    use std::{fs, path::PathBuf};
 
     use crate::common::{
         create_dir, create_dir_and_write_file, create_yolo_project_config, image_data,
@@ -37,7 +37,7 @@ mod tests {
         create_yolo_project_config.source_paths.images = export_source_dir.clone();
         create_yolo_project_config.source_paths.labels = export_source_dir.clone();
 
-        create_yolo_project_config.export.paths.root = export_out_dir.clone();
+        create_yolo_project_config.export.paths.root = PathBuf::from(&export_out_dir);
 
         let num_of_pairs = 10;
         for i in 0..num_of_pairs {
@@ -65,23 +65,21 @@ mod tests {
             "jpg",
             "txt",
         );
-        let train_image_path = format!("{}/train/images", exported_config.export.paths.root);
+        let train_image_path = exported_config.export.paths.root.join("train/images");
 
-        let num_train_image_files = fs::read_dir(train_image_path)
+        let num_train_image_files = fs::read_dir(&train_image_path)
             .expect("Unable to read train folder")
             .count();
 
         // Check validation folder has 2 label, 2 image
-        let num_validation_image_files = fs::read_dir(format!(
-            "{}/validation/images",
-            exported_config.export.paths.root
-        ))
-        .unwrap()
-        .count();
+        let num_validation_image_files =
+            fs::read_dir(exported_config.export.paths.root.join("validation/images"))
+                .unwrap()
+                .count();
 
         // Check test folder has 2 label, 2 image
         let num_test_image_files =
-            fs::read_dir(format!("{}/test/images", exported_config.export.paths.root))
+            fs::read_dir(exported_config.export.paths.root.join("test/images"))
                 .unwrap()
                 .count();
 
@@ -100,7 +98,7 @@ mod tests {
             "txt",
         );
 
-        let yolo_yaml_path = format!("{}/test_project.yaml", exported_config.export.paths.root);
+        let yolo_yaml_path = exported_config.export.paths.root.join("test_project.yaml");
 
         let expected_yaml = r#"# Generate by yolo_io - https://github.com/Ladvien/yolo_io
 path: tests/sandbox/export_test_yolo_yaml_created
@@ -113,7 +111,7 @@ names:
   1: car
 "#;
 
-        let yolo_yaml = fs::read_to_string(yolo_yaml_path).expect("Unable to read yolo.yaml");
+        let yolo_yaml = fs::read_to_string(&yolo_yaml_path).expect("Unable to read yolo.yaml");
 
         assert_eq!(yolo_yaml, expected_yaml);
     }
@@ -129,9 +127,9 @@ names:
         );
 
         let image_dirs = vec![
-            format!("{}/train/images", exported_config.export.paths.root),
-            format!("{}/validation/images", exported_config.export.paths.root),
-            format!("{}/test/images", exported_config.export.paths.root),
+            exported_config.export.paths.root.join("train/images"),
+            exported_config.export.paths.root.join("validation/images"),
+            exported_config.export.paths.root.join("test/images"),
         ];
 
         for dir in image_dirs {
@@ -142,9 +140,9 @@ names:
         }
 
         let label_dirs = vec![
-            format!("{}/train/labels", exported_config.export.paths.root),
-            format!("{}/validation/labels", exported_config.export.paths.root),
-            format!("{}/test/labels", exported_config.export.paths.root),
+            exported_config.export.paths.root.join("train/labels"),
+            exported_config.export.paths.root.join("validation/labels"),
+            exported_config.export.paths.root.join("test/labels"),
         ];
 
         for dir in label_dirs {


### PR DESCRIPTION
## Summary
- refactor `Paths` to store `PathBuf` values instead of raw strings
- join directories using `PathBuf::join`
- update exporter logic and tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686bc5083ea883228717a80e1d4e8919