### PR TITLE
Fix index access safety

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,8 +157,10 @@ impl YoloProject {
     }
 
     /// Access a valid pair by index.
-    pub fn pair_at_index(&self, index: isize) -> Option<ImageLabelPair> {
-        self.get_valid_pairs().get(index as usize).cloned()
+    ///
+    /// Returns `None` if the index is out of bounds.
+    pub fn pair_at_index(&self, index: usize) -> Option<ImageLabelPair> {
+        self.get_valid_pairs().get(index).cloned()
     }
 
     fn get_file_stems(filenames: &[&PathWithKey]) -> Vec<String> {

--- a/tests/pairing_tests.rs
+++ b/tests/pairing_tests.rs
@@ -213,4 +213,29 @@ mod pairing_tests {
 
         assert!(valid_pair.is_some());
     }
+
+    #[rstest]
+    fn test_pair_at_index_out_of_range(
+        image_data: ImageBuffer<Rgb<u8>, Vec<u8>>,
+        mut create_yolo_project_config: YoloProjectConfig,
+    ) {
+        let filename = "index_out_of_range";
+        let this_test_directory = format!("{}/{}/", TEST_SANDBOX_DIR, filename);
+
+        let image_file = PathBuf::from(format!("{}/test.jpg", this_test_directory));
+        create_image_file(&image_file, &image_data);
+
+        let label_file = PathBuf::from(format!("{}/test.txt", this_test_directory));
+        create_dir_and_write_file(&label_file, "0 0.5 0.5 0.5 0.5");
+
+        create_yolo_project_config.source_paths.images = this_test_directory.clone();
+        create_yolo_project_config.source_paths.labels = this_test_directory.clone();
+
+        let project =
+            YoloProject::new(&create_yolo_project_config).expect("Unable to create project");
+
+        let pair = project.pair_at_index(1);
+
+        assert!(pair.is_none());
+    }
 }


### PR DESCRIPTION
## Summary
- enforce non-negative index for `pair_at_index`
- test out-of-range `pair_at_index` call

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686bc510a4308322bb118d9850f6ccf6