### PR TITLE
Improve README quick start example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,18 @@ Add the crate to your `Cargo.toml`:
 yolo_io = "0.1.103"
 ```
 
-Load your project and export it back out:
+Load your project and export it back out. A complete example is provided in
+`examples/minimal.rs`:
 
 ```rust
-use yolo_io::*;
+use yolo_io::{YoloProjectConfig, YoloProject, YoloProjectExporter};
 
-let config = YoloProjectConfig::new("examples/config.yaml")?;
-let project = YoloProject::new(&config)?;
-YoloProjectExporter::export(project)?;
-# Ok::<(), Box<dyn std::error::Error>>(())
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = YoloProjectConfig::new("examples/config.yaml")?;
+    let project = YoloProject::new(&config)?;
+    YoloProjectExporter::export(project)?;
+    Ok(())
+}
 ```
 
 Run the included example (requires the sample dataset in `examples/`):

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,0 +1,10 @@
+//! Minimal example that mirrors the Quick Start snippet in the README.
+
+use yolo_io::{YoloProject, YoloProjectConfig, YoloProjectExporter};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = YoloProjectConfig::new("examples/config.yaml")?;
+    let project = YoloProject::new(&config)?;
+    YoloProjectExporter::export(project)?;
+    Ok(())
+}

--- a/tests/export_tests.rs
+++ b/tests/export_tests.rs
@@ -110,22 +110,24 @@ mod tests {
 
         let num_train_image_files = fs::read_dir(format!(
             "{}/train/images",
-            exported_config.export.paths.root
+            exported_config.export.paths.root.display()
         ))
         .unwrap()
         .count();
 
         let num_validation_image_files = fs::read_dir(format!(
             "{}/validation/images",
-            exported_config.export.paths.root
+            exported_config.export.paths.root.display()
         ))
         .unwrap()
         .count();
 
-        let num_test_image_files =
-            fs::read_dir(format!("{}/test/images", exported_config.export.paths.root))
-                .unwrap()
-                .count();
+        let num_test_image_files = fs::read_dir(format!(
+            "{}/test/images",
+            exported_config.export.paths.root.display()
+        ))
+        .unwrap()
+        .count();
 
         assert_eq!(num_train_image_files, 2);
         assert_eq!(num_validation_image_files, 2);


### PR DESCRIPTION
## Summary
- clarify the Quick Start snippet with an explicit `main` function
- link to `examples/minimal.rs`
- add a new minimal example file
- adjust tests to compile on stable

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686bdffdaf448322ac58097bcb97b49d