### PR TITLE
Add compile test for examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,9 @@ clap = { version = "4.4.18", features = ["derive"] }
 
 [dev-dependencies]
 image = "0.25.4" # https://docs.rs/image/latest/image/
-num-complex = "0.4.6" 
+num-complex = "0.4.6"
 rstest = "0.23.0" # https://docs.rs/rstest/latest/rstest/
+assert_cmd = "2.0"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/examples/programmatic.rs
+++ b/examples/programmatic.rs
@@ -1,0 +1,34 @@
+use hashbrown::HashMap;
+use yolo_io::*;
+
+fn main() {
+    let mut class_map = HashMap::new();
+    class_map.insert(0, "sample".to_string());
+
+    let config = YoloProjectConfig {
+        source_paths: SourcePaths {
+            images: "examples/images".to_string(),
+            labels: "examples/labels".to_string(),
+        },
+        r#type: "yolo".to_string(),
+        project_name: "programmatic".to_string(),
+        export: Export {
+            paths: Paths {
+                train: "train".into(),
+                validation: "validation".into(),
+                test: "test".into(),
+                root: "examples/export".into(),
+            },
+            class_map,
+            duplicate_tolerance: 0.01,
+            split: Split {
+                train: 1.0,
+                validation: 0.0,
+                test: 0.0,
+            },
+        },
+    };
+
+    let project = YoloProject::new(&config).expect("Failed to create project");
+    YoloProjectExporter::export(project).expect("Failed to export project");
+}

--- a/tests/example_compile_test.rs
+++ b/tests/example_compile_test.rs
@@ -1,0 +1,17 @@
+#[cfg(test)]
+mod example_compile_test {
+    use assert_cmd::Command;
+
+    #[test]
+    fn build_examples() {
+        Command::new("cargo")
+            .args(["build", "--example", "basic"])
+            .assert()
+            .success();
+
+        Command::new("cargo")
+            .args(["build", "--example", "programmatic"])
+            .assert()
+            .success();
+    }
+}


### PR DESCRIPTION
## Summary
- add a programmatic example for testing
- ensure `examples/basic.rs` and `examples/programmatic.rs` build
- add `assert_cmd` for running cargo in tests

## Testing
- `cargo fmt --check`
- `cargo test --quiet` *(fails: `yolo_io` could not compile test `export_tests`)*

------
https://chatgpt.com/codex/tasks/task_e_686be0017a9c832297ee9db2c84c3254